### PR TITLE
Add no-dupe-class-member rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ For more details about configuration please refer to the dedicated section in th
 
 ### Best practices
 
-| Rule ID                                                      | Description                        |
-| ------------------------------------------------------------ | ---------------------------------- |
-| [lwc/no-inner-html](./docs/rules/no-inner-html.md)           | disallow usage of `innerHTML`      |
-| [lwc/no-async-operation](./docs/rules/no-async-operation.md) | restrict usage of async operations |
+| Rule ID                                                            | Description                        |
+| ------------------------------------------------------------------ | ---------------------------------- |
+| [lwc/no-dupe-class-members](./docs/rules/no-dupe-class-members.md) | disallow duplicate class members   |
+| [lwc/no-inner-html](./docs/rules/no-inner-html.md)                 | disallow usage of `innerHTML`      |
+| [lwc/no-async-operation](./docs/rules/no-async-operation.md)       | restrict usage of async operations |
 
 ### Compat performance
 

--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -1,0 +1,45 @@
+# Disallow duplicate class members (no-dupe-class-members)
+
+If there are declarations of the same name in class members, the last declaration overwrites other declarations silently. It can cause unexpected behaviors. This rule prevents usage of duplicate class members (fields and methods) on the same class.
+
+> Note: This rule extends the original eslint rule [`no-dupe-class-members`](https://eslint.org/docs/rules/no-dupe-class-members) to add support for [class fields](https://github.com/tc39/proposal-class-fields) that are not yet stage 4.
+
+## Rule details
+
+Example of **incorrect** code:
+
+```js
+class Foo {
+    bar() {}
+    bar() {}
+}
+
+class Foo {
+    bar;
+    bar() {}
+}
+
+class Foo {
+    bar;
+    get bar() {}
+}
+```
+
+Example of **correct** code:
+
+```js
+class Foo {
+    foo() {}
+    bar() {}
+}
+
+class Foo {
+    foo;
+    bar() {}
+}
+
+class Foo {
+    foo;
+    get bar() {}
+}
+```

--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -1,6 +1,6 @@
 # Disallow duplicate class members (no-dupe-class-members)
 
-If there are declarations of the same name in class members, the last declaration overwrites other declarations silently. It can cause unexpected behaviors. This rule prevents usage of duplicate class members (fields and methods) on the same class.
+If there are declarations of the same name in class members, the last declaration overwrites other declarations silently. This can cause unexpected behaviors. This rule prevents usage of duplicate class members (fields and methods) on the same class.
 
 > Note: This rule extends the original eslint rule [`no-dupe-class-members`](https://eslint.org/docs/rules/no-dupe-class-members) to add support for [class fields](https://github.com/tc39/proposal-class-fields) that are not yet stage 4.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,16 +7,17 @@
 'use strict';
 
 const rules = {
-    'no-async-await': require('./rules/no-async-await.js'),
+    'no-async-await': require('./rules/no-async-await'),
     'no-async-operation': require('./rules/no-async-operation'),
-    'no-deprecated': require('./rules/no-deprecated.js'),
-    'no-document-query': require('./rules/no-document-query.js'),
-    'no-for-of': require('./rules/no-for-of.js'),
-    'no-inner-html': require('./rules/no-inner-html.js'),
-    'no-rest-parameter': require('./rules/no-rest-parameter.js'),
-    'valid-api': require('./rules/valid-api.js'),
-    'valid-track': require('./rules/valid-track.js'),
-    'valid-wire': require('./rules/valid-wire.js'),
+    'no-deprecated': require('./rules/no-deprecated'),
+    'no-document-query': require('./rules/no-document-query'),
+    'no-dupe-class-members': require('./rules/no-dupe-class-members'),
+    'no-for-of': require('./rules/no-for-of'),
+    'no-inner-html': require('./rules/no-inner-html'),
+    'no-rest-parameter': require('./rules/no-rest-parameter'),
+    'valid-api': require('./rules/valid-api'),
+    'valid-track': require('./rules/valid-track'),
+    'valid-wire': require('./rules/valid-wire'),
 };
 
 module.exports = {

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -32,11 +32,11 @@ module.exports = {
         /**
          * Gets state of a given member name.
          * @param {string} name - A name of a member.
-         * @param {boolean} isStatic - A flag which specifies that is a static member.
+         * @param {boolean} isStatic - A flag which specifies if a member is static.
          * @returns {Object} A state of a given member name.
-         *   - retv.init {boolean} A flag which shows the name is declared as normal member.
-         *   - retv.get {boolean} A flag which shows the name is declared as getter.
-         *   - retv.set {boolean} A flag which shows the name is declared as setter.
+         *   - retv.init {boolean} A flag which shows that the name is declared as normal member.
+         *   - retv.get {boolean} A flag which shows that the name is declared as getter.
+         *   - retv.set {boolean} A flag which shows that the name is declared as setter.
          */
         function getState(name, isStatic) {
             const stateMap = stack[stack.length - 1];

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { docUrl } = require('../util/doc-url');
+
+/**
+ * Code inspired form: https://github.com/eslint/eslint/blob/2c7431d6b32063f74e3837ee727f26af215eada7/lib/rules/no-dupe-class-members.js
+ * Author: Toru Nagashima
+ * Copyright JS Foundation and other contributors, https://js.foundation
+ */
+module.exports = {
+    meta: {
+        docs: {
+            description: 'disallow duplicate class members',
+            category: 'LWC',
+            url: docUrl('no-dupe-class-members'),
+        },
+        schema: [],
+        messages: {
+            unexpected: "Duplicate name '{{name}}'.",
+        },
+    },
+
+    create(context) {
+        let stack = [];
+
+        /**
+         * Gets state of a given member name.
+         * @param {string} name - A name of a member.
+         * @param {boolean} isStatic - A flag which specifies that is a static member.
+         * @returns {Object} A state of a given member name.
+         *   - retv.init {boolean} A flag which shows the name is declared as normal member.
+         *   - retv.get {boolean} A flag which shows the name is declared as getter.
+         *   - retv.set {boolean} A flag which shows the name is declared as setter.
+         */
+        function getState(name, isStatic) {
+            const stateMap = stack[stack.length - 1];
+            const key = `$${name}`; // to avoid "__proto__".
+
+            if (!stateMap[key]) {
+                stateMap[key] = {
+                    nonStatic: { init: false, get: false, set: false },
+                    static: { init: false, get: false, set: false },
+                };
+            }
+
+            return stateMap[key][isStatic ? 'static' : 'nonStatic'];
+        }
+
+        function getName(node) {
+            switch (node.type) {
+                case 'Identifier':
+                    return node.name;
+                case 'Literal':
+                    return String(node.value);
+
+                /* istanbul ignore next */
+                default:
+                    return '';
+            }
+        }
+
+        return {
+            Program() {
+                stack = [];
+            },
+
+            // Initializes state of member declarations for the class.
+            ClassBody() {
+                stack.push(Object.create(null));
+            },
+
+            // Disposes the state for the class.
+            'ClassBody:exit'() {
+                stack.pop();
+            },
+
+            MethodDefinition(node) {
+                if (node.computed) {
+                    return;
+                }
+
+                const name = getName(node.key);
+                const state = getState(name, node.static);
+                let isDuplicate = false;
+
+                if (node.kind === 'get') {
+                    isDuplicate = state.init || state.get;
+                    state.get = true;
+                } else if (node.kind === 'set') {
+                    isDuplicate = state.init || state.set;
+                    state.set = true;
+                } else {
+                    isDuplicate = state.init || state.get || state.set;
+                    state.init = true;
+                }
+
+                if (isDuplicate) {
+                    context.report({ node, messageId: 'unexpected', data: { name } });
+                }
+            },
+
+            ClassProperty(node) {
+                if (node.computed) {
+                    return;
+                }
+
+                const name = getName(node.key);
+                const state = getState(name, node.static);
+                const isDuplicate = state.init || state.get || state.set;
+
+                state.init = true;
+
+                if (isDuplicate) {
+                    context.report({ node, messageId: 'unexpected', data: { name } });
+                }
+            },
+        };
+    },
+};

--- a/test/lib/rules/no-dupe-class-members.js
+++ b/test/lib/rules/no-dupe-class-members.js
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { RuleTester } = require('eslint');
+
+const { ESLINT_TEST_CONFIG } = require('../shared');
+const rule = require('../../../lib/rules/no-dupe-class-members');
+
+const ruleTester = new RuleTester(ESLINT_TEST_CONFIG);
+
+ruleTester.run('no-dupe-class-members', rule, {
+    valid: [
+        // Original rule tests:
+        // https://github.com/eslint/eslint/blob/2c7431d6b32063f74e3837ee727f26af215eada7/tests/lib/rules/no-dupe-class-members.js#L23
+        'class A { foo() {} bar() {} }',
+        'class A { static foo() {} foo() {} }',
+        'class A { get foo() {} set foo(value) {} }',
+        'class A { static foo() {} get foo() {} set foo(value) {} }',
+        'class A { foo() { } } class B { foo() { } }',
+        'class A { [foo]() {} foo() {} }',
+        "class A { 'foo'() {} 'bar'() {} baz() {} }",
+        "class A { *'foo'() {} *'bar'() {} *baz() {} }",
+        "class A { get 'foo'() {} get 'bar'() {} get baz() {} }",
+        'class A { 1() {} 2() {} }',
+
+        // Custom logic with class fields
+        'class A { foo; bar; }',
+        'class A { foo; [foo]; }',
+        'class A { foo; bar() {} }',
+        'class A { foo; static foo; }',
+        'class A { foo; static foo() {} }',
+        "class A { 'foo'; static 'foo'; }",
+        "class A { 'foo'; static 'foo'() {} }",
+        'class A { static foo; static bar; }',
+        "class A { static 'foo'; static 'bar'; }",
+    ],
+    invalid: [
+        // Original rule tests:
+        // https://github.com/eslint/eslint/blob/2c7431d6b32063f74e3837ee727f26af215eada7/tests/lib/rules/no-dupe-class-members.js#L35
+        {
+            code: 'class A { foo() {} foo() {} }',
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 20,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+        {
+            code: '!class A { foo() {} foo() {} };',
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 21,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+        {
+            code: "class A { 'foo'() {} 'foo'() {} }",
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 22,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+        {
+            code: 'class A { 10() {} 1e1() {} }',
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 19,
+                    messageId: 'unexpected',
+                    data: { name: '10' },
+                },
+            ],
+        },
+        {
+            code: 'class A { foo() {} foo() {} foo() {} }',
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 20,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 29,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+        {
+            code: 'class A { static foo() {} static foo() {} }',
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 27,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+        {
+            code: 'class A { foo() {} get foo() {} }',
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 20,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+        {
+            code: 'class A { set foo(value) {} foo() {} }',
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 29,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+
+        // Custom logic with class fields
+        {
+            code: 'class A { foo; foo; }',
+            errors: [
+                {
+                    type: 'ClassProperty',
+                    line: 1,
+                    column: 16,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+        {
+            code: 'class A { foo; foo() {} }',
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 16,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+        {
+            code: 'class A { foo; get foo() {} set foo(v) {} }',
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 16,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 29,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+        {
+            code: "class A { 'foo'; foo() {} }",
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 18,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+        {
+            code: 'class A { static foo; static foo() {} }',
+            errors: [
+                {
+                    type: 'MethodDefinition',
+                    line: 1,
+                    column: 23,
+                    messageId: 'unexpected',
+                    data: { name: 'foo' },
+                },
+            ],
+        },
+    ],
+});


### PR DESCRIPTION
This rule prevents usage of duplicate class members (fields and methods) on the same class. Here is an example of code the rule would flag that `bar` is declared twice on the same class.

```js
class Foo {
    bar;
    bar() {}
}
```