### PR TITLE
feat: Add no-api-reassignments rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For more details about configuration please refer to the dedicated section in th
 | Rule ID                                                                                    | Description                                                       | Fixable |
 | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- | ------- |
 | [lwc/consistent-component-name](./docs/rules/consistent-component-name.md)                 | ensure component class name matches file name                     | 🔧      |
+| [lwc/no-api-reassignments](./docs/rules/no-api-reassignments.md)                           | prevent public property reassignments                             |         |
 | [lwc/no-deprecated](./docs/rules/no-deprecated.md)                                         | disallow usage of deprecated LWC APIs                             |         |
 | [lwc/no-document-query](./docs/rules/no-document-query.md)                                 | disallow DOM query at the document level                          |         |
 | [lwc/no-leading-uppercase-api-name](./docs/rules/no-leading-uppercase-api-name.md)         | ensure public property doesn't start with an upper-case character |         |

--- a/docs/rules/no-api-reassignments.md
+++ b/docs/rules/no-api-reassignments.md
@@ -1,0 +1,48 @@
+# Prevent public property reassignments (no-api-reassignments)
+
+Public properties should be set by the parent component and never reassigned by the child. This linting rule prevents reassignment of a component's public properties.
+
+## Rule details
+
+Example of **incorrect** code:
+
+```js
+import { LightningElement, api } from 'lwc';
+
+export default class Test extends LightningElement {
+    @api foo;
+
+    constructor() {
+        super();
+        this.foo = 1;
+    }
+
+    method() {
+        this.foo = 1;
+
+        return () => {
+            this.foo = 1;
+        };
+    }
+}
+```
+
+Example of **correct** code:
+
+```js
+export default class Test extends LightningElement {
+    @api foo = 1;
+}
+```
+
+## When not to use it
+
+If the component needs to reflect internal state changes via public property, this rule should not be used. A good example for this is a custom input component reflecting its internal value change to the `value` public property.
+
+## Caveats
+
+This rule suffers from the following caveats:
+
+-   It expects that all the class methods are invoked with the component instance as the `this` value. If a class method is invoked with a different `this` and happens to reassign a property that is also declared as a public property, this rule reports a false positive.
+-   It doesn't track public property reassignment when the `this` value is aliased (eg. `const that = this`).
+-   It doesn't track public property reassignment where the component instance is passed as argument or as the `this` value using `Function.prototype.call()`, `Function.prototype.apply()` or `Function.prototype.bind()`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@
 
 const rules = {
     'consistent-component-name': require('./rules/consistent-component-name'),
+    'no-api-reassignments': require('./rules/no-api-reassignments'),
     'no-async-await': require('./rules/no-async-await'),
     'no-async-operation': require('./rules/no-async-operation'),
     'no-deprecated': require('./rules/no-deprecated'),

--- a/lib/rules/no-api-reassignments.js
+++ b/lib/rules/no-api-reassignments.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { docUrl } = require('../util/doc-url');
+const { getPublicProperties } = require('../util/decorator-util');
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'prevent public property reassignments',
+            category: 'LWC',
+            recommended: true,
+            url: docUrl('no-api-reassignments'),
+        },
+        schema: [],
+    },
+
+    create(context) {
+        /**
+         * Tracks the public properties that are accessible from the current scope.
+         */
+        let classScope = null;
+
+        /**
+         * Creates and pushes a new class scope onto the stack for the given class body.
+         */
+        function enterClassBody(node) {
+            classScope = {
+                upper: classScope,
+                publicProperties: getPublicProperties(node),
+            };
+        }
+
+        /**
+         * Pops the current class scope from the stack.
+         */
+        function exitClassBody() {
+            classScope = classScope.upper;
+        }
+
+        /**
+         * Creates and pushes a new empty class scope if the given function declaration is not a
+         * method declaration on the class.
+         */
+        function enterFunction(node) {
+            if (node.parent.type !== 'MethodDefinition') {
+                classScope = {
+                    upper: classScope,
+                    publicProperties: [],
+                };
+            }
+        }
+
+        /**
+         * Pops the current class scope from the stack, if the given function declaration is not a
+         * method declaration on the class.
+         */
+        function exitFunction(node) {
+            if (node.parent.type !== 'MethodDefinition') {
+                classScope = classScope.upper;
+            }
+        }
+
+        /**
+         * Emits a message if the given assignment expression is done on public property present
+         * in the current scope.
+         */
+        function reportReassignment(node) {
+            // Early exit if the assignment is not on property assigned to the this value.
+            if (
+                node.left.type !== 'MemberExpression' ||
+                node.left.object.type !== 'ThisExpression' ||
+                node.left.property.type !== 'Identifier'
+            ) {
+                return;
+            }
+
+            // Check if reassigned property is public property available in the current scope.
+            const propertyName = node.left.property.name;
+            if (
+                classScope &&
+                classScope.publicProperties.some(
+                    prop => prop.name === propertyName && prop.type !== 'method',
+                )
+            ) {
+                context.report({
+                    message: `Invalid reassignment of public property "${propertyName}"`,
+                    node,
+                });
+            }
+        }
+
+        return {
+            AssignmentExpression: reportReassignment,
+            ClassBody: enterClassBody,
+            'ClassBody:exit': exitClassBody,
+            FunctionDeclaration: enterFunction,
+            'FunctionDeclaration:exit': exitFunction,
+            FunctionExpression: enterFunction,
+            'FunctionExpression:exit': exitFunction,
+        };
+    },
+};

--- a/lib/rules/no-leading-uppercase-api-name.js
+++ b/lib/rules/no-leading-uppercase-api-name.js
@@ -7,7 +7,7 @@
 'use strict';
 
 const { docUrl } = require('../util/doc-url');
-const { isApiDecorator } = require('../util/decorator-util');
+const { getPublicProperties } = require('../util/decorator-util');
 
 module.exports = {
     meta: {
@@ -23,18 +23,14 @@ module.exports = {
 
     create(context) {
         return {
-            Decorator(node) {
-                const { parent } = node;
+            ClassBody(node) {
+                const publicProperties = getPublicProperties(node);
 
-                if (isApiDecorator(node)) {
-                    if (
-                        parent.key.type === 'Identifier' &&
-                        parent.key.name.length &&
-                        parent.key.name[0] === parent.key.name[0].toUpperCase()
-                    ) {
+                for (const publicProperty of publicProperties) {
+                    if (publicProperty.name[0] === publicProperty.name[0].toUpperCase()) {
                         context.report({
                             node,
-                            message: `Invalid property name syntax in "${parent.key.name}". Property name must start with a lowercase character.`,
+                            message: `Invalid property name syntax in "${publicProperty.name}". Property name must start with a lowercase character.`,
                         });
                     }
                 }

--- a/lib/util/decorator-util.js
+++ b/lib/util/decorator-util.js
@@ -10,9 +10,10 @@ const API_DECORATOR_IDENTIFIER = 'api';
 const WIRE_DECORATOR_IDENTIFIER = 'wire';
 
 /**
- * Returns true if the node is an 'api' decorator (@api)
+ * Checks if the given node is an 'api' decorator (@api)
  *
  * @param {ASTNode} node The AST node being checked.
+ * @returns {boolean} true if the given node is an 'api' decorator otherwise false.
  */
 function isApiDecorator(node) {
     return (
@@ -22,6 +23,12 @@ function isApiDecorator(node) {
     );
 }
 
+/**
+ * Checks if the given node is a 'wire' decorator (@wire)
+ *
+ * @param {ASTNode} node The AST node being checked.
+ * @returns {boolean} true if the given node is a 'wire' decorator otherwise false.
+ */
 function isWireDecorator(node) {
     return (
         node.type === 'Decorator' &&
@@ -31,9 +38,48 @@ function isWireDecorator(node) {
     );
 }
 
+/**
+ * Returns list of all the available public properties on a class. It only returns the list public
+ * properties where the public name is known.
+ *
+ * @param {ASTNode} node The class body AST node.
+ * @returns {Array} a list the public properties with their name and associated node.
+ */
+function getPublicProperties(node) {
+    return node.body
+        .filter(node => {
+            return (
+                node.key.type === 'Identifier' &&
+                node.decorators &&
+                node.decorators.some(isApiDecorator)
+            );
+        })
+        .map(node => {
+            let type;
+            if (node.type === 'ClassProperty') {
+                type = 'property';
+            } else if (node.type === 'MethodDefinition') {
+                if (node.kind === 'get') {
+                    type = 'getter';
+                } else if (node.kind === 'set') {
+                    type = 'setter';
+                } else {
+                    type = 'method';
+                }
+            }
+
+            return {
+                name: node.key.name,
+                type,
+                node,
+            };
+        });
+}
+
 module.exports = {
     API_DECORATOR_IDENTIFIER,
     WIRE_DECORATOR_IDENTIFIER,
     isApiDecorator,
     isWireDecorator,
+    getPublicProperties,
 };

--- a/test/lib/rules/no-api-reassignments.js
+++ b/test/lib/rules/no-api-reassignments.js
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { RuleTester } = require('eslint');
+
+const { ESLINT_TEST_CONFIG } = require('../shared');
+const rule = require('../../../lib/rules/no-api-reassignments');
+
+const ruleTester = new RuleTester(ESLINT_TEST_CONFIG);
+
+ruleTester.run('no-api-reassignments', rule, {
+    valid: [
+        {
+            code: `this.foo = 1;`,
+        },
+        {
+            code: `class Test {
+                @api foo;
+            }`,
+        },
+        {
+            code: `class Test {
+                @api foo = 1;
+            }`,
+        },
+        {
+            code: `class Test {
+                @api foo;
+
+                method(obj) {
+                    obj.foo = 1;
+                }
+            }`,
+        },
+        {
+            code: `class Test {
+                @api foo;
+
+                method() {
+                    function test() {
+                        this.foo = 1;
+                    }
+                }
+            }`,
+        },
+        {
+            code: `class Test {
+                @api foo;
+
+                method() {
+                    const test = function() {
+                        this.foo = 1;
+                    }
+                }
+            }`,
+        },
+        {
+            code: `class Test {
+                @api foo;
+
+                method() {
+                    const obj = {
+                        inner() {
+                            this.foo = 1;
+                        }
+                    }
+                }
+            }`,
+        },
+        {
+            code: `class Test {
+                @api 
+                foo() {
+                    this.foo = 1;
+                }
+            }`,
+        },
+    ],
+    invalid: [
+        {
+            code: `class Test {
+                @api foo;
+
+                method() {
+                    this.foo = 1;
+                }
+            }`,
+            errors: [
+                {
+                    message: 'Invalid reassignment of public property "foo"',
+                },
+            ],
+        },
+        {
+            code: `class Test {
+                @api 
+                set foo(v) {}
+
+                method() {
+                    this.foo = 1;
+                }
+            }`,
+            errors: [
+                {
+                    message: 'Invalid reassignment of public property "foo"',
+                },
+            ],
+        },
+        {
+            code: `class Test {
+                @api 
+                get foo() {}
+
+                method() {
+                    this.foo = 1;
+                }
+            }`,
+            errors: [
+                {
+                    message: 'Invalid reassignment of public property "foo"',
+                },
+            ],
+        },
+        {
+            code: `class Test {
+                @api foo;
+
+                method() {
+                    const obj = {
+                        inner: () => {
+                            this.foo = 1;
+                        }
+                    }
+                }
+            }`,
+            errors: [
+                {
+                    message: 'Invalid reassignment of public property "foo"',
+                },
+            ],
+        },
+        {
+            code: `class Test {
+                @api foo;
+
+                method() {
+                    {
+                        this.foo = 1;
+                    }
+                }
+            }`,
+            errors: [
+                {
+                    message: 'Invalid reassignment of public property "foo"',
+                },
+            ],
+        },
+        {
+            code: `class Test {
+                @api foo;
+
+                method() {
+                    const test = () => {
+                        this.foo = 1;
+                    }
+                }
+            }`,
+            errors: [
+                {
+                    message: 'Invalid reassignment of public property "foo"',
+                },
+            ],
+        },
+        {
+            code: `class Test {
+                @api foo;
+
+                method = () => {
+                    this.foo = 1;
+                }
+            }`,
+            errors: [
+                {
+                    message: 'Invalid reassignment of public property "foo"',
+                },
+            ],
+        },
+    ],
+});


### PR DESCRIPTION
## Details

Add `no-api-reassignments` linting rule to prevent public property reassignment.
This PR also unifies public properties and methods gathering.

Fixes #27.

## GUS Work Item

W-7200635