### PR TITLE
feat: Add no-leaky-event-listeners rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ For more details about configuration please refer to the dedicated section in th
 
 ### Best practices
 
-| Rule ID                                                            | Description                        | Fixable |
-| ------------------------------------------------------------------ | ---------------------------------- | ------- |
-| [lwc/no-dupe-class-members](./docs/rules/no-dupe-class-members.md) | disallow duplicate class members   |         |
-| [lwc/no-inner-html](./docs/rules/no-inner-html.md)                 | disallow usage of `innerHTML`      |         |
-| [lwc/no-async-operation](./docs/rules/no-async-operation.md)       | restrict usage of async operations |         |
+| Rule ID                                                                  | Description                                 | Fixable |
+| ------------------------------------------------------------------------ | ------------------------------------------- | ------- |
+| [lwc/no-async-operation](./docs/rules/no-async-operation.md)             | restrict usage of async operations          |         |
+| [lwc/no-dupe-class-members](./docs/rules/no-dupe-class-members.md)       | disallow duplicate class members            |         |
+| [lwc/no-inner-html](./docs/rules/no-inner-html.md)                       | disallow usage of `innerHTML`               |         |
+| [lwc/no-leaky-event-listeners](./docs/rules/no-leaky-event-listeners.md) | prevent event listeners from leaking memory |         |
 
 ### Compat performance
 

--- a/docs/rules/no-leaky-event-listeners.md
+++ b/docs/rules/no-leaky-event-listeners.md
@@ -1,0 +1,47 @@
+## Prevent event listeners from leaking memory (no-leaky-event-listeners)
+
+It is extremely easy to leak event listeners. In most of the cases, not only the event handler leaks, but also all the object capture into closure. This rules prevents common patterns associated with event listener leaking.
+
+### Rule details
+
+Example of **incorrect** code:
+
+```js
+import { LightningElement } from 'lwc';
+
+export default class Test extends LightningElement {
+    connectedCallback() {
+        window.addEventListener('test', handleTest.bind(this));
+        //                              ^ Event listener will leak.
+    }
+
+    disconnectedCallback() {
+        window.removeEventListener('test', handleTest.bind(this));
+        //                                 ^ Event listener will leak.
+    }
+
+    handleTest() {}
+}
+```
+
+In the code above the event listener will leak because invoking `Function.prototype.bind()` on a method returns a new method with a bound `this` value. Since the component doesn't have a reference to the newly created function, the added event listener can't be removed later on. In this case, since the `this` value is trapped into the generated function, each newly created component will be kept in memory.
+
+Example of **correct** code:
+
+```js
+import { LightningElement } from 'lwc';
+
+export default class Test extends LightningElement {
+    connectedCallback() {
+        window.addEventListener('test', this.handleTest);
+    }
+
+    disconnectedCallback() {
+        window.removeEventListener('test', this.handleTest);
+    }
+
+    handleTest = () => {};
+}
+```
+
+In the example above we were able to get rid of the `Function.prototype.bind()` by using a class field associated with an arrow function. The `this` value uses in the arrow function body will always be the component instance.

--- a/docs/rules/no-leaky-event-listeners.md
+++ b/docs/rules/no-leaky-event-listeners.md
@@ -1,6 +1,6 @@
 ## Prevent event listeners from leaking memory (no-leaky-event-listeners)
 
-It is extremely easy to leak event listeners. In most of the cases, not only the event handler leaks, but also all the object capture into closure. This rules prevents common patterns associated with event listener leaking.
+It is extremely easy to leak event listeners. In most of the cases the event handler leaks as well as all the objects captured in the closure. This rules prevents common patterns associated with event listener leaking.
 
 ### Rule details
 
@@ -24,7 +24,7 @@ export default class Test extends LightningElement {
 }
 ```
 
-In the code above the event listener will leak because invoking `Function.prototype.bind()` on a method returns a new method with a bound `this` value. Since the component doesn't have a reference to the newly created function, the added event listener can't be removed later on. In this case, since the `this` value is trapped into the generated function, each newly created component will be kept in memory.
+In the code above the event listener will leak because invoking `Function.prototype.bind()` on a method returns a new method. Since the component doesn't have a reference to the newly created function, the added event listener can't be subsequently removed. Also, the `this` value is closured into the generated function so the component is kept in memory.
 
 Example of **correct** code:
 
@@ -44,4 +44,4 @@ export default class Test extends LightningElement {
 }
 ```
 
-In the example above we were able to get rid of the `Function.prototype.bind()` by using a class field associated with an arrow function. The `this` value uses in the arrow function body will always be the component instance.
+In the example above we were able to get rid of the `Function.prototype.bind()` by using a class field associated with an arrow function. The `this` value used in the arrow function body will always be the component instance.

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ const rules = {
     'no-for-of': require('./rules/no-for-of'),
     'no-inner-html': require('./rules/no-inner-html'),
     'no-leading-uppercase-api-name': require('./rules/no-leading-uppercase-api-name'),
+    'no-leaky-event-listeners': require('./rules/no-leaky-event-listeners'),
     'no-unexpected-wire-adapter-usages': require('./rules/no-unexpected-wire-adapter-usages'),
     'no-rest-parameter': require('./rules/no-rest-parameter'),
     'no-unknown-wire-adapters': require('./rules/no-unknown-wire-adapters'),

--- a/lib/rules/no-leaky-event-listeners.js
+++ b/lib/rules/no-leaky-event-listeners.js
@@ -43,16 +43,25 @@ module.exports = {
         }
 
         /**
+         * Returns the root object of a member expression.
+         */
+        function getExpressionRootNode(node) {
+            switch (node.type) {
+                case 'MemberExpression':
+                    return getExpressionRootNode(node.object);
+
+                case 'CallExpression':
+                    return getExpressionRootNode(node.callee);
+
+                default:
+                    return node;
+            }
+        }
+
+        /**
          * Emits if a given call expression is dealing with an event listener that would leak.
          */
-        function reportListenerLeak(callExpression, { target, method }) {
-            // Early exit if the considered EventTarget is not the document or the window. Event
-            // listeners added programmatically on a component element will automatically be
-            // garbage collected when the component is destroyed.
-            if (target !== 'window' && target !== 'document') {
-                return;
-            }
-
+        function reportListenerLeak(callExpression, { method }) {
             if (callExpression.arguments.length < 2) {
                 return;
             }
@@ -88,30 +97,42 @@ module.exports = {
             CallExpression(node) {
                 const { callee } = node;
 
-                // Handle cases where the method is attached on the global object. eg:
-                // addEventListener('click', () => {});
+                // Handle cases where the method is attached on the global object:
+                // - addEventListener('click', () => {});
                 if (
                     callee.type === 'Identifier' &&
                     isIdentifierGlobal(callee) &&
                     isValidEventListenerMethodName(callee.name)
                 ) {
-                    reportListenerLeak(node, { target: 'window', method: callee.name });
+                    reportListenerLeak(node, { method: callee.name });
                 }
 
-                // Handle cases where invoking the event listener method on an object. eg:
-                // window.addEventListener('click', () => {});
+                // Handle cases where invoking the event listener method on an object:
+                //  - window.addEventListener('click', () => {});
+                //  - document.body.addEventListener('click', () => {});
+                //  - document.querySelector('#modal').addEventListener('click', () => {});
+                //
+                // Note: This routine only track handlers attached to nodes that are access via the
+                // "document" or the "window" object to avoid false positives. Event listeners added
+                // programmatically on a component element will automatically be garbage collected
+                // when the component is destroyed.
                 if (
                     callee.type === 'MemberExpression' &&
                     callee.computed === false &&
-                    callee.object.type === 'Identifier' &&
-                    isIdentifierGlobal(callee.object) &&
                     callee.property.type === 'Identifier' &&
                     isValidEventListenerMethodName(callee.property.name)
                 ) {
-                    reportListenerLeak(node, {
-                        target: callee.object.name,
-                        method: callee.property.name,
-                    });
+                    const rootNode = getExpressionRootNode(callee);
+
+                    if (
+                        rootNode.type === 'Identifier' &&
+                        isIdentifierGlobal(rootNode) &&
+                        (rootNode.name === 'window' || rootNode.name === 'document')
+                    ) {
+                        reportListenerLeak(node, {
+                            method: callee.property.name,
+                        });
+                    }
                 }
             },
         };

--- a/lib/rules/no-leaky-event-listeners.js
+++ b/lib/rules/no-leaky-event-listeners.js
@@ -22,7 +22,7 @@ module.exports = {
 
     create(context) {
         /**
-         * Returns true if the passed Identifier node is referencing a property on the global
+         * Returns true if the passed identifier node is referencing a property on the global
          * object.
          */
         function isIdentifierGlobal(identifier) {
@@ -36,19 +36,19 @@ module.exports = {
         }
 
         /**
-         * Returns true of the passed string is a valid event listener method.
+         * Returns true if the passed string is a valid event listener method.
          */
         function isValidEventListenerMethodName(name) {
             return name === 'addEventListener' || name === 'removeEventListener';
         }
 
         /**
-         * Emits if a given call expression dealing with an event listener that would leak.
+         * Emits if a given call expression is dealing with an event listener that would leak.
          */
         function reportListenerLeak(callExpression, { target, method }) {
             // Early exit if the considered EventTarget is not the document or the window. Event
             // listeners added programmatically on a component element will automatically be
-            // garbage collected.
+            // garbage collected when the component is destroyed.
             if (target !== 'window' && target !== 'document') {
                 return;
             }
@@ -57,7 +57,7 @@ module.exports = {
                 return;
             }
 
-            // The following handlers are considered leaking because they create brand new function
+            // The following handlers are considered leaky because they create a brand new function
             // every time:
             // - addEventListener('click', function () {});
             // - addEventListener('click', () => {});

--- a/lib/rules/no-leaky-event-listeners.js
+++ b/lib/rules/no-leaky-event-listeners.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { docUrl } = require('../util/doc-url');
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'prevent event listeners from leaking memory',
+            category: 'LWC',
+            recommended: true,
+            url: docUrl('no-leaky-event-listeners'),
+        },
+
+        schema: [],
+    },
+
+    create(context) {
+        /**
+         * Returns true if the passed Identifier node is referencing a property on the global
+         * object.
+         */
+        function isIdentifierGlobal(identifier) {
+            let scope = context.getScope(identifier);
+
+            while (scope.upper) {
+                scope = scope.upper;
+            }
+
+            return scope.through.find(variable => variable.identifier === identifier);
+        }
+
+        /**
+         * Returns true of the passed string is a valid event listener method.
+         */
+        function isValidEventListenerMethodName(name) {
+            return name === 'addEventListener' || name === 'removeEventListener';
+        }
+
+        /**
+         * Emits if a given call expression dealing with an event listener that would leak.
+         */
+        function reportListenerLeak(callExpression, { target, method }) {
+            // Early exit if the considered EventTarget is not the document or the window. Event
+            // listeners added programmatically on a component element will automatically be
+            // garbage collected.
+            if (target !== 'window' && target !== 'document') {
+                return;
+            }
+
+            if (callExpression.arguments.length < 2) {
+                return;
+            }
+
+            // The following handlers are considered leaking because they create brand new function
+            // every time:
+            // - addEventListener('click', function () {});
+            // - addEventListener('click', () => {});
+            // - addEventListener('click', handler.bind(context));
+            const handler = callExpression.arguments[1];
+            if (
+                handler.type === 'ArrowFunctionExpression' ||
+                handler.type === 'FunctionExpression' ||
+                (handler.type === 'CallExpression' &&
+                    handler.callee.type === 'MemberExpression' &&
+                    handler.callee.computed === false &&
+                    handler.callee.property.type === 'Identifier' &&
+                    handler.callee.property.name === 'bind')
+            ) {
+                const message =
+                    method === 'addEventListener'
+                        ? 'Event listener will leak. Make sure keep a reference to the handler to remove it later.'
+                        : 'Event listener will leak. The passed handler is different than the registered one.';
+
+                context.report({
+                    message,
+                    node: callExpression,
+                });
+            }
+        }
+
+        return {
+            CallExpression(node) {
+                const { callee } = node;
+
+                // Handle cases where the method is attached on the global object. eg:
+                // addEventListener('click', () => {});
+                if (
+                    callee.type === 'Identifier' &&
+                    isIdentifierGlobal(callee) &&
+                    isValidEventListenerMethodName(callee.name)
+                ) {
+                    reportListenerLeak(node, { target: 'window', method: callee.name });
+                }
+
+                // Handle cases where invoking the event listener method on an object. eg:
+                // window.addEventListener('click', () => {});
+                if (
+                    callee.type === 'MemberExpression' &&
+                    callee.computed === false &&
+                    callee.object.type === 'Identifier' &&
+                    isIdentifierGlobal(callee.object) &&
+                    callee.property.type === 'Identifier' &&
+                    isValidEventListenerMethodName(callee.property.name)
+                ) {
+                    reportListenerLeak(node, {
+                        target: callee.object.name,
+                        method: callee.property.name,
+                    });
+                }
+            },
+        };
+    },
+};

--- a/lib/rules/no-leaky-event-listeners.js
+++ b/lib/rules/no-leaky-event-listeners.js
@@ -72,13 +72,13 @@ module.exports = {
                     handler.callee.property.type === 'Identifier' &&
                     handler.callee.property.name === 'bind')
             ) {
-                const message =
+                const detail =
                     method === 'addEventListener'
-                        ? 'Event listener will leak. Make sure keep a reference to the handler to remove it later.'
-                        : 'Event listener will leak. The passed handler is different than the registered one.';
+                        ? 'Make sure to keep a reference to the handler to remove it subsequently.'
+                        : 'The passed handler is different than the registered one.';
 
                 context.report({
-                    message,
+                    message: `Event listener will leak. ${detail}`,
                     node: callExpression,
                 });
             }

--- a/test/lib/rules/no-leaky-event-listeners.js
+++ b/test/lib/rules/no-leaky-event-listeners.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { RuleTester } = require('eslint');
+
+const { ESLINT_TEST_CONFIG } = require('../shared');
+const rule = require('../../../lib/rules/no-leaky-event-listeners');
+
+const ruleTester = new RuleTester(ESLINT_TEST_CONFIG);
+
+function buildCases({ targets, methods, handlers }) {
+    const cases = [];
+
+    for (const target of targets) {
+        for (const method of methods) {
+            for (const handler of handlers) {
+                const code = `${method}('test', ${handler});`;
+                cases.push({
+                    code: target === null ? code : `${target}.${code}`,
+                });
+            }
+        }
+    }
+
+    return cases;
+}
+
+const basicValidCases = buildCases({
+    targets: [null, 'document', 'window'],
+    methods: ['addEventListener', 'removeEventListener'],
+    handlers: ['', 'handleTest', 'this.handleTest', "getListener('test')"],
+});
+
+const basicInvalidCases = buildCases({
+    targets: [null, 'document', 'window'],
+    methods: ['addEventListener', 'removeEventListener'],
+    handlers: ['function() { return handleTest(); }', '() => handleTest', 'handleTest.bind(this)'],
+}).map(entry => {
+    return {
+        ...entry,
+        errors: [
+            {
+                message: /^Event listener will leak\./,
+            },
+        ],
+    };
+});
+
+ruleTester.run('no-leaky-event-listeners', rule, {
+    valid: [
+        ...basicValidCases,
+
+        // Global object properties shadowing.
+        {
+            code: `
+                function addEventListener() {}
+                addEventListener('test', () => handleTest());
+            `,
+        },
+        {
+            code: `
+                const window = {};
+                window.addEventListener('test', () => handleTest());
+            `,
+        },
+
+        // Unknown EventTarget.
+        {
+            code: `
+                foo.addEventListener('test', () => handleTest());
+            `,
+        },
+    ],
+    invalid: basicInvalidCases,
+});

--- a/test/lib/rules/no-leaky-event-listeners.js
+++ b/test/lib/rules/no-leaky-event-listeners.js
@@ -33,7 +33,7 @@ function buildCases({ targets, methods, handlers }) {
 const basicValidCases = buildCases({
     targets: [null, 'document', 'window'],
     methods: ['addEventListener', 'removeEventListener'],
-    handlers: ['', 'handleTest', 'this.handleTest', "getListener('test')"],
+    handlers: ['', 'undefined', 'null', 'handleTest', 'this.handleTest', "getListener('test')"],
 });
 
 const basicInvalidCases = buildCases({


### PR DESCRIPTION
## Changes

This PR introduces the `lwc/no-leaky-event-listeners` linting rule. This rule prevents common patterns from event listeners leaking memory.

## GUS work item

W-7109631