### PR TITLE
feat(no-unknown-wire-adapters): support module and identifier as a glob pattern

### DIFF
--- a/docs/rules/no-unknown-wire-adapters.md
+++ b/docs/rules/no-unknown-wire-adapters.md
@@ -14,17 +14,21 @@ This rule can be configured as follows:
 
         // for modules exporting wire adapters using default exports
         { module: '<module name>', identifier: 'default' },
+
+        // to match multiple adapters, use glob patterns
+        { module: '<module name glob pattern>', identifier: '<adapter identifier glob pattern>' },
     ];
 }
 ```
 
-Any usage of the `@wire` decorator will be flagged as an error unless a list of known adapters has been provided or the adapter is imported from a supported namespace.
+Any usage of the `@wire` decorator will be flagged as an error unless a list of known adapters has been provided.
 
 ```js
-/*eslint lwc/no-unexpected-wire-adapters: ["error", {"adapters": [{"module": "myAdapters", "identifier": "fooAdapter"}], "supportedNamespaces: ["@salesforce/apex/"]}]*/
+/*eslint lwc/no-unexpected-wire-adapters: ["error", {"adapters": [{"module": "myAdapters", "identifier": "fooAdapter"}, {"module": "@salesforce/apex/*", "identifier": "*"}]}]*/
 
 import { LightningElement, wire } from 'lwc';
 import { apexMethod } from '@salesforce/apex/Namespace.Classname.apexMethodReference';
+import { otherApexMethod } from '@salesforce/apex/Namespace/Classname.apexMethodReference';
 import defaultAdapter, { fooAdapter, barAdapter } from 'myAdapters';
 
 export default class Example extends LightningElement {
@@ -37,7 +41,10 @@ export default class Example extends LightningElement {
     @wire(defaultAdapter) // invalid, missing adapter in config: {"module": "myAdapters", "identifier": "default"}
     default;
  
-    @wire(apexMethod) // valid, @salesforce/apex/ is a supported namespace.
+    @wire(apexMethod) // valid
     apexMethodResult;
+
+    @wire(otherApexMethod) // invalid, does not match "@salesforce/apex/*" glob pattern
+    otherApexMethodResult;
 }
 ```

--- a/docs/rules/no-unknown-wire-adapters.md
+++ b/docs/rules/no-unknown-wire-adapters.md
@@ -18,12 +18,13 @@ This rule can be configured as follows:
 }
 ```
 
-Any usage of the `@wire` decorator will be flagged as an error unless a list of known adapters has been provided.
+Any usage of the `@wire` decorator will be flagged as an error unless a list of known adapters has been provided or the adapter is imported from a supported namespace.
 
 ```js
-/*eslint lwc/no-unexpected-wire-adapters: ["error", {"adapters": [{"module": "myAdapters", "identifier": "fooAdapter"}]}]*/
+/*eslint lwc/no-unexpected-wire-adapters: ["error", {"adapters": [{"module": "myAdapters", "identifier": "fooAdapter"}], "supportedNamespaces: ["@salesforce/apex/"]}]*/
 
 import { LightningElement, wire } from 'lwc';
+import { apexMethod } from '@salesforce/apex/Namespace.Classname.apexMethodReference';
 import defaultAdapter, { fooAdapter, barAdapter } from 'myAdapters';
 
 export default class Example extends LightningElement {
@@ -35,5 +36,8 @@ export default class Example extends LightningElement {
 
     @wire(defaultAdapter) // invalid, missing adapter in config: {"module": "myAdapters", "identifier": "default"}
     default;
+ 
+    @wire(apexMethod) // valid, @salesforce/apex/ is a supported namespace.
+    apexMethodResult;
 }
 ```

--- a/lib/rules/no-unknown-wire-adapters.js
+++ b/lib/rules/no-unknown-wire-adapters.js
@@ -7,7 +7,7 @@
 'use strict';
 
 const { docUrl } = require('../util/doc-url');
-const Minimatch = require("minimatch").Minimatch;
+const { Minimatch } = require("minimatch");
 
 module.exports = {
     meta: {

--- a/lib/rules/no-unknown-wire-adapters.js
+++ b/lib/rules/no-unknown-wire-adapters.js
@@ -36,6 +36,12 @@ module.exports = {
                             },
                         },
                     },
+                    supportedNamespaces: {
+                        type: 'array',
+                        items: {
+                            type: 'string',
+                        },
+                    },
                 },
                 additionalProperties: false,
             },
@@ -44,6 +50,7 @@ module.exports = {
 
     create(context) {
         const knownAdapters = context.options[0].adapters;
+        const supportedNamespaces = context.options[0].supportedNamespaces || [];
 
         return {
             Decorator(node) {
@@ -98,8 +105,12 @@ module.exports = {
                         ? adapterDeclarationNode.parent.imported.name
                         : 'default';
 
+                const adapterModuleIsInSupportedNamespace = supportedNamespaces.some(
+                    supportedNamespace => adapterModule.startsWith(supportedNamespace)
+                );
+
                 // Finally check if the imported identifier originates from a known module.
-                const isKnownAdapter = knownAdapters.some((adapter) => {
+                const isKnownAdapter = adapterModuleIsInSupportedNamespace || knownAdapters.some((adapter) => {
                     return (
                         adapter.module === adapterModule && adapter.identifier === adapterIdentifier
                     );

--- a/lib/rules/no-unknown-wire-adapters.js
+++ b/lib/rules/no-unknown-wire-adapters.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const { docUrl } = require('../util/doc-url');
+const Minimatch = require("minimatch").Minimatch;
 
 module.exports = {
     meta: {
@@ -36,12 +37,6 @@ module.exports = {
                             },
                         },
                     },
-                    supportedNamespaces: {
-                        type: 'array',
-                        items: {
-                            type: 'string',
-                        },
-                    },
                 },
                 additionalProperties: false,
             },
@@ -49,8 +44,12 @@ module.exports = {
     },
 
     create(context) {
-        const knownAdapters = context.options[0].adapters;
-        const supportedNamespaces = context.options[0].supportedNamespaces || [];
+        const knownAdapters = context.options[0].adapters.map((adapter) => {
+            return {
+                module: new Minimatch(adapter.module),
+                identifier: new Minimatch(adapter.identifier),
+            }
+        });
 
         return {
             Decorator(node) {
@@ -105,14 +104,10 @@ module.exports = {
                         ? adapterDeclarationNode.parent.imported.name
                         : 'default';
 
-                const adapterModuleIsInSupportedNamespace = supportedNamespaces.some(
-                    supportedNamespace => adapterModule.startsWith(supportedNamespace)
-                );
-
                 // Finally check if the imported identifier originates from a known module.
-                const isKnownAdapter = adapterModuleIsInSupportedNamespace || knownAdapters.some((adapter) => {
+                const isKnownAdapter = knownAdapters.some((adapter) => {
                     return (
-                        adapter.module === adapterModule && adapter.identifier === adapterIdentifier
+                        adapter.module.match(adapterModule) && adapter.identifier.match(adapterIdentifier)
                     );
                 });
                 if (!isKnownAdapter) {

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "tabWidth": 4,
     "singleQuote": true,
     "trailingComma": "all"
+  },
+  "dependencies": {
+    "minimatch": "^3.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "nyc": "^15.0.1",
     "prettier": "^2.0.5"
   },
+  "dependencies": {
+    "minimatch": "^3.0.4"
+  },
   "peerDependencies": {
     "babel-eslint": ">=10.0.0",
     "eslint": ">=6.0.0"
@@ -72,8 +75,5 @@
     "tabWidth": 4,
     "singleQuote": true,
     "trailingComma": "all"
-  },
-  "dependencies": {
-    "minimatch": "^3.0.4"
   }
 }

--- a/test/lib/rules/no-unknown-wire-adapters.js
+++ b/test/lib/rules/no-unknown-wire-adapters.js
@@ -122,6 +122,42 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
                 },
             ],
         },
+        {
+            code: `import { wire } from 'lwc';
+            import { apexMethod } from '@salesforce/apex/Namespace.Classname.apexMethodReference';
+
+            class Test {
+                @wire(apexMethod)
+                wiredProp;
+            }`,
+            options: [
+                {
+                    adapters: [],
+                    supportedNamespaces: ['@salesforce/apex/'],
+                },
+            ],
+        },
+        {
+            code: `import { wire } from 'lwc';
+            import { getFoo } from 'adapterFoo';
+            import { apexMethod } from '@salesforce/apex/Namespace.Classname.apexMethodReference';
+
+            class Test {
+                @wire(apexMethod)
+                wiredProp;
+                
+                @wire(getFoo)
+                wiredFoo;
+            }`,
+            options: [
+                {
+                    adapters: [
+                        { module: 'adapterFoo', identifier: 'getFoo' },
+                    ],
+                    supportedNamespaces: ['@salesforce/apex/'],
+                },
+            ],
+        },
     ],
     invalid: [
         {
@@ -195,6 +231,25 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
             errors: [
                 {
                     message: '"getFoo" from "adapter" is not a known adapter.',
+                },
+            ],
+        },
+        {
+            code: `import { wire } from 'lwc';
+            import startRequest from '@salesforce/apexContinuation/SampleContinuationClass.startRequest';
+
+            class Test {
+                @wire(startRequest) wiredProp;
+            }`,
+            options: [
+                {
+                    adapters: [{ module: 'adapter', identifier: 'getBar' }],
+                    supportedNamespaces: ['@salesforce/apex/'],
+                },
+            ],
+            errors: [
+                {
+                    message: '"default" from "@salesforce/apexContinuation/SampleContinuationClass.startRequest" is not a known adapter.',
                 },
             ],
         },


### PR DESCRIPTION
In some cases like [apex adapters](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.apex), we don’t know the adapters before hand.

This PR adds support for globs in the `module` and `identifier` property, allowing (mark as known) all wire adapters matching the `module` and `identifier` glob patterns.

