### PR TITLE
Fix no-leaky-event-listeners example

### DIFF
--- a/docs/rules/no-leaky-event-listeners.md
+++ b/docs/rules/no-leaky-event-listeners.md
@@ -11,13 +11,14 @@ import { LightningElement } from 'lwc';
 
 export default class Test extends LightningElement {
     connectedCallback() {
-        window.addEventListener('test', handleTest.bind(this));
+        window.addEventListener('test', this.handleTest.bind(this));
         //                              ^ Event listener will leak.
     }
 
     disconnectedCallback() {
-        window.removeEventListener('test', handleTest.bind(this));
-        //                                 ^ Event listener will leak.
+        window.removeEventListener('test', this.handleTest.bind(this));
+        //                                 ^ The original event listener will not be removed because
+        //                                   invoking .bind() returns a branch new function.
     }
 
     handleTest() {}


### PR DESCRIPTION
The previous example was an invalid JavaScript code. This PR fixes the example and adds more detail on why the event listener removal doesn't work as expected.