### PR TITLE
feat: Add prefer-custom-event rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ To choose from three configuration settings, install the [`eslint-config-lwc`](h
 
 ### Best practices
 
-| Rule ID                                                                  | Description                                 | Fixable |
-| ------------------------------------------------------------------------ | ------------------------------------------- | ------- |
-| [lwc/no-async-operation](./docs/rules/no-async-operation.md)             | restrict usage of async operations          |         |
-| [lwc/no-dupe-class-members](./docs/rules/no-dupe-class-members.md)       | disallow duplicate class members            |         |
-| [lwc/no-inner-html](./docs/rules/no-inner-html.md)                       | disallow usage of `innerHTML`               |         |
-| [lwc/no-leaky-event-listeners](./docs/rules/no-leaky-event-listeners.md) | prevent event listeners from leaking memory |         |
+| Rule ID                                                                  | Description                                             | Fixable |
+| ------------------------------------------------------------------------ | ------------------------------------------------------- | ------- |
+| [lwc/no-async-operation](./docs/rules/no-async-operation.md)             | restrict usage of async operations                      |         |
+| [lwc/no-dupe-class-members](./docs/rules/no-dupe-class-members.md)       | disallow duplicate class members                        |         |
+| [lwc/no-inner-html](./docs/rules/no-inner-html.md)                       | disallow usage of `innerHTML`                           |         |
+| [lwc/no-leaky-event-listeners](./docs/rules/no-leaky-event-listeners.md) | prevent event listeners from leaking memory             |         |
+| [lwc/prefer-custom-event](./docs/rules/prefer-custom-event.md)           | suggest usage of `CustomEvent` over `Event` constructor |         |
 
 ### Compat performance
 

--- a/docs/rules/prefer-custom-event.md
+++ b/docs/rules/prefer-custom-event.md
@@ -1,0 +1,28 @@
+# Suggest usage of `CustomEvent` over `Event` constructor (prefer-custom-event)
+
+`CustomEvent` is a standard `Event` that can also carry any data. The main added benefit of creating an event using the `CustomEvent` constructor over `Event` is that the `detail` property carrying the data is readonly.
+
+```js
+const evt1 = new CustomEvent('test', { detail: 'original' });
+evt1.detail = 'updated'; // (throws an error in strict mode)
+console.log(evt1.detail); // original
+
+const evt2 = new Event('test');
+evt2.detail = 'original';
+evt2.detail = 'updated';
+console.log(evt2.detail); // updated
+```
+
+## Rule details
+
+Example of **incorrect** code:
+
+```js
+const evt = new Event('test');
+```
+
+Example of **correct** code:
+
+```js
+const evt = new CustomEvent('test');
+```

--- a/docs/rules/prefer-custom-event.md
+++ b/docs/rules/prefer-custom-event.md
@@ -1,6 +1,6 @@
 # Suggest usage of `CustomEvent` over `Event` constructor (prefer-custom-event)
 
-`CustomEvent` is a standard `Event` that can also carry any data. The main added benefit of creating an event using the `CustomEvent` constructor over `Event` is that the `detail` property carrying the data is readonly.
+`CustomEvent` is a type of DOM `Event` that can also carry any data. The main benefit of creating an event using the `CustomEvent` constructor over `Event` is that the `detail` property carrying the data is readonly.
 
 ```js
 const evt1 = new CustomEvent('test', { detail: 'original' });

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ const rules = {
     'no-rest-parameter': require('./rules/no-rest-parameter'),
     'no-unknown-wire-adapters': require('./rules/no-unknown-wire-adapters'),
     'no-window-top': require('./rules/no-window-top'),
+    'prefer-custom-event': require('./rules/prefer-custom-event'),
     'valid-api': require('./rules/valid-api'),
     'valid-track': require('./rules/valid-track'),
     'valid-wire': require('./rules/valid-wire'),

--- a/lib/rules/prefer-custom-event.js
+++ b/lib/rules/prefer-custom-event.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { docUrl } = require('../util/doc-url');
+const { isGlobalIdentifier } = require('../util/scope');
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'suggest usage of "CustomEvent" over "Event" constructor',
+            category: 'LWC',
+            recommended: true,
+            url: docUrl('prefer-custom-event'),
+        },
+
+        schema: [],
+    },
+
+    create(context) {
+        return {
+            NewExpression(node) {
+                const { callee } = node;
+                const scope = context.getScope();
+
+                if (
+                    callee.type === 'Identifier' &&
+                    callee.name === 'Event' &&
+                    isGlobalIdentifier(callee, scope)
+                ) {
+                    context.report({
+                        node,
+                        message:
+                            'Prefer using "CustomEvent" constructor over "Event" for dispatching events.',
+                    });
+                }
+            },
+        };
+    },
+};

--- a/test/lib/rules/prefer-custom-event.js
+++ b/test/lib/rules/prefer-custom-event.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { RuleTester } = require('eslint');
+
+const { ESLINT_TEST_CONFIG } = require('../shared');
+const rule = require('../../../lib/rules/prefer-custom-event');
+
+const ruleTester = new RuleTester(ESLINT_TEST_CONFIG);
+
+ruleTester.run('prefer-custom-event', rule, {
+    valid: [
+        {
+            code: `new CustomEvent('test');`,
+        },
+        {
+            code: `
+                class Event {}
+                new Event('test');
+            `,
+        },
+    ],
+    invalid: [
+        {
+            code: `new Event('test');`,
+            errors: [
+                {
+                    message:
+                        'Prefer using "CustomEvent" constructor over "Event" for dispatching events.',
+                },
+            ],
+        },
+        {
+            code: `new Event('test');`,
+            env: {
+                browser: true,
+            },
+            errors: [
+                {
+                    message:
+                        'Prefer using "CustomEvent" constructor over "Event" for dispatching events.',
+                },
+            ],
+        },
+    ],
+});


### PR DESCRIPTION
This PR adds a new linting rule to suggest using `CustomEvent` instead of `Event`.

**⚠️ This PR need to be merged after #47 ⚠️**