### PR TITLE
docs: update valide-api README and correct option name

### DIFF
--- a/docs/rules/valid-api.md
+++ b/docs/rules/valid-api.md
@@ -7,7 +7,6 @@ The following restrictions apply to the `@api` decorator:
 -   Fields and methods can't start with `on`. The `on` prefix is reserved to bind event handlers.
 -   Fields and methods can't start with `data`, `slot` or `part`. These names are reserved by LWC.
 -   Boolean properties must be initialized with `false`. By initializing a public property to `true`, the consumer component can't set its value to `false` via the template.
--   Fields and methods can't contain both uppercase and underscore characters.
 
 ## Rule details
 
@@ -39,13 +38,6 @@ class Foo {
     @api
     foo = 2;
 }
-
-class Foo {
-    @api
-    Foo_;
-    @api
-    fO_o;
-}
 ```
 
 Example of **correct** code:
@@ -73,5 +65,40 @@ class Foo {
 class Foo {
     @api
     foo() {}
+}
+```
+
+## Options
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "disallowUnderscoreUppercaseMix": {
+            "type": "boolean"
+        }
+    },
+    "additionalProperties": false
+}
+```
+
+### `disallowUnderscoreUppercaseMix`
+
+This property controls is if the rule should allow or not public properties and methods with mixed upper case and underscore character. It is not recommended to mix uppercase and underscore characters for public properties because those properties can't be referenced from the template.
+
+By default, this property is set to `false`.
+
+Example of **incorrect** code:
+
+```js
+/* eslint lwc/valid-api: ["error", { "disallowUnderscoreUppercaseMix": true }] */
+import { api } from 'lwc';
+
+class Foo {
+    @api
+    Foo_;
+
+    @api
+    fO_o;
 }
 ```

--- a/docs/rules/valid-api.md
+++ b/docs/rules/valid-api.md
@@ -84,7 +84,7 @@ class Foo {
 
 ### `disallowUnderscoreUppercaseMix`
 
-This property controls is if the rule should allow or not public properties and methods with mixed upper case and underscore character. It is not recommended to mix uppercase and underscore characters for public properties because those properties can't be referenced from the template.
+This property controls whether the rule allows the name of a public property or method to contain both uppercase and underscore characters. Mixing uppercase and underscore characters in public properties isn't recommended, because those properties can't be referenced from the template.
 
 By default, this property is set to `false`.
 

--- a/lib/rules/valid-api.js
+++ b/lib/rules/valid-api.js
@@ -94,7 +94,7 @@ function validatePropertyName(property, context) {
         });
     }
 
-    if (context.options[0] && context.options[0].dissallowUnderscoreUppercaseMix) {
+    if (context.options[0] && context.options[0].disallowUnderscoreUppercaseMix) {
         if (name.match(MIX_UPPERCASE_AND_UNDERSCORE)) {
             context.report({
                 node: property,
@@ -133,7 +133,7 @@ module.exports = {
             {
                 type: 'object',
                 properties: {
-                    dissallowUnderscoreUppercaseMix: {
+                    disallowUnderscoreUppercaseMix: {
                         type: 'boolean',
                     },
                 },

--- a/test/lib/rules/valid-api.js
+++ b/test/lib/rules/valid-api.js
@@ -74,21 +74,21 @@ ruleTester.run('valid-api', rule, {
         class Foo {
             @api bar_foo() {}
         }`,
-            options: [{ dissallowUnderscoreUppercaseMix: true }],
+            options: [{ disallowUnderscoreUppercaseMix: true }],
         },
         {
             code: `import { api } from 'lwc';
         class Foo {
             @api barFoo() {}
         }`,
-            options: [{ dissallowUnderscoreUppercaseMix: true }],
+            options: [{ disallowUnderscoreUppercaseMix: true }],
         },
         {
             code: `import { api } from 'lwc';
         class Foo {
             @api foobar() {}
         }`,
-            options: [{ dissallowUnderscoreUppercaseMix: true }],
+            options: [{ disallowUnderscoreUppercaseMix: true }],
         },
     ],
     invalid: [
@@ -241,7 +241,7 @@ ruleTester.run('valid-api', rule, {
                         'Avoid using both uppercase and underscores in property names: "bar_Foo"',
                 },
             ],
-            options: [{ dissallowUnderscoreUppercaseMix: true }],
+            options: [{ disallowUnderscoreUppercaseMix: true }],
         },
         {
             code: `import { api } from 'lwc';
@@ -254,7 +254,7 @@ ruleTester.run('valid-api', rule, {
                         'Avoid using both uppercase and underscores in property names: "_barFoo"',
                 },
             ],
-            options: [{ dissallowUnderscoreUppercaseMix: true }],
+            options: [{ disallowUnderscoreUppercaseMix: true }],
         },
         {
             code: `import { api } from 'lwc';
@@ -267,7 +267,7 @@ ruleTester.run('valid-api', rule, {
                         'Avoid using both uppercase and underscores in property names: "_barfoO"',
                 },
             ],
-            options: [{ dissallowUnderscoreUppercaseMix: true }],
+            options: [{ disallowUnderscoreUppercaseMix: true }],
         },
         {
             code: `import { api } from 'lwc';
@@ -280,7 +280,7 @@ ruleTester.run('valid-api', rule, {
                         'Avoid using both uppercase and underscores in property names: "Foo_bar"',
                 },
             ],
-            options: [{ dissallowUnderscoreUppercaseMix: true }],
+            options: [{ disallowUnderscoreUppercaseMix: true }],
         },
         {
             code: `import { api } from 'lwc';
@@ -293,7 +293,7 @@ ruleTester.run('valid-api', rule, {
                         'Avoid using both uppercase and underscores in property names: "Foobar_"',
                 },
             ],
-            options: [{ dissallowUnderscoreUppercaseMix: true }],
+            options: [{ disallowUnderscoreUppercaseMix: true }],
         },
     ],
 });


### PR DESCRIPTION
This PR update the `valid-api` documentation with the newly introduced option and correct the option name (`disallowUnderscoreUppercaseMix`).