### PR TITLE
fix: handle case where assignment expression isn't member expression

### DIFF
--- a/lib/rules/no-attributes-during-construction.js
+++ b/lib/rules/no-attributes-during-construction.js
@@ -131,7 +131,7 @@ module.exports = {
                     for (const expression of assignmentExpressions) {
                         const { left } = expression;
                         const { computed, object, property } = left;
-                        if (object.type === 'ThisExpression' && !computed) {
+                        if (object && object.type === 'ThisExpression' && !computed) {
                             const { name } = property;
                             if (
                                 PROPERTIES_THAT_REFLECT.has(name) &&

--- a/test/lib/rules/no-attributes-during-construction.js
+++ b/test/lib/rules/no-attributes-during-construction.js
@@ -17,6 +17,19 @@ ruleTester.run('no-attributes-during-construction', rule, {
     valid: [
         {
             code: `
+                import { LightningElement } from 'lwc';
+                let tabIndex;
+                class Test extends LightningElement {
+                    tabIndex = '-1';
+                    constructor() {
+                        super();
+                        tabIndex = '0';
+                    }
+                }
+            `,
+        },
+        {
+            code: `
                 class LightningElement {}
                 class Test extends LightningElement {
                     constructor() {


### PR DESCRIPTION
`AssignmentExpression` > `MemberExpression` > `ThisExpression`

We were doing checks for `AssignmentExpression` and `ThisExpression` but not `MemberExpression`.