### PR TITLE
fix: enhance no-unknown-wire-adapters by reporting in wire usage

### DIFF
--- a/lib/rules/no-unknown-wire-adapters.js
+++ b/lib/rules/no-unknown-wire-adapters.js
@@ -93,7 +93,7 @@ module.exports = {
                     adapterDeclarationNode.parent.type !== 'ImportDefaultSpecifier'
                 ) {
                     return context.report({
-                        node: adapterDeclarationNode,
+                        node: adapterNode,
                         message: `"${adapterName}" is not a known adapter.`,
                     });
                 }
@@ -115,7 +115,7 @@ module.exports = {
                 if (!isKnownAdapter) {
                     const localAdapterIdentifier = adapterDeclarationNode.parent.local.name;
                     return context.report({
-                        node: adapterDeclarationNode,
+                        node: adapterNode,
                         message: `"${localAdapterIdentifier}" from "${adapterModule}" is not a known adapter.`,
                     });
                 }

--- a/test/lib/rules/no-unknown-wire-adapters.js
+++ b/test/lib/rules/no-unknown-wire-adapters.js
@@ -182,6 +182,8 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
             errors: [
                 {
                     message: '"getFoo" is not a known adapter.',
+                    line: 4,
+                    column: 23,
                 },
             ],
         },
@@ -211,6 +213,8 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
             errors: [
                 {
                     message: '"getFoo" is not a known adapter.',
+                    line: 5,
+                    column: 23,
                 },
             ],
         },
@@ -225,6 +229,33 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
             errors: [
                 {
                     message: '"getFoo" from "adapter" is not a known adapter.',
+                    line: 5,
+                    column: 23,
+                },
+            ],
+        },
+        // reports multiple occurrences
+        {
+            code: `import { wire } from 'lwc';
+            import { getFoo } from 'adapter';
+
+            class Test {
+                @wire(getFoo) wiredProp;
+                
+                @wire(getFoo)
+                wiredMethod() {}
+            }`,
+            options: DEFAULT_OPTIONS,
+            errors: [
+                {
+                    message: '"getFoo" from "adapter" is not a known adapter.',
+                    line: 5,
+                    column: 23,
+                },
+                {
+                    message: '"getFoo" from "adapter" is not a known adapter.',
+                    line: 7,
+                    column: 23,
                 },
             ],
         },
@@ -243,6 +274,8 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
             errors: [
                 {
                     message: '"getFoo" from "adapter" is not a known adapter.',
+                    line: 5,
+                    column: 23,
                 },
             ],
         },
@@ -262,6 +295,8 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
             errors: [
                 {
                     message: '"getPost" from "adapter" is not a known adapter.',
+                    line: 5,
+                    column: 23,
                 },
             ],
         },
@@ -281,6 +316,8 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
             errors: [
                 {
                     message: '"getFoo" from "adapter" is not a known adapter.',
+                    line: 5,
+                    column: 23,
                 },
             ],
         },
@@ -302,6 +339,8 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
                 {
                     message:
                         '"apexMethod" from "@salesforce/apex/Namespace.Classname.apexMethodReference" is not a known adapter.',
+                    line: 5,
+                    column: 23,
                 },
             ],
         },
@@ -327,6 +366,8 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
                 {
                     message:
                         '"apexMethod" from "@salesforce/apex/Namespace.Classname.apexMethodReference" is not a known adapter.',
+                    line: 6,
+                    column: 23,
                 },
             ],
         },
@@ -346,6 +387,8 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
                 {
                     message:
                         '"startRequest" from "@salesforce/apex/Continuation/SampleContinuationClass.startRequest" is not a known adapter.',
+                    line: 5,
+                    column: 23,
                 },
             ],
         },
@@ -365,6 +408,8 @@ ruleTester.run('no-unknown-wire-adapters', rule, {
                 {
                     message:
                         '"startRequest" from "@salesforce/apexContinuation/SampleContinuationClass.startRequest" is not a known adapter.',
+                    line: 5,
+                    column: 23,
                 },
             ],
         },


### PR DESCRIPTION
This PR updates the [`lwc/no-unknown-wire-adapters`](https://github.com/salesforce/eslint-plugin-lwc/blob/master/docs/rules/no-unknown-wire-adapters.md) so that the error message is reported in the `@wire` usage node instead of the import (declaration).