### PR TITLE
fix: Drop ESLint 6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,40 +1,25 @@
 version: 2.1
 
-jobs: 
+jobs:
   build:
     docker:
       - image: circleci/node
-
-    parameters:
-      eslint:
-        type: string
 
     steps:
       - checkout
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "yarn.lock" }}-<< parameters.eslint >>
+          - v1-dependencies-{{ checksum "yarn.lock" }}
           - v1-dependencies-
-      
+
       - run: yarn install --frozen-lock
 
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "yarn.lock" }}-<< parameters.eslint >>
-
-      - run: yarn add --dev eslint@<< parameters.eslint >>
-
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
+      
       - run: yarn format:check
       - run: yarn lint
       - run: yarn test
-
-workflows:
-  workflow:
-    jobs:
-      - build:
-          name: build-eslint-v<<matrix.eslint>>
-          matrix:
-            parameters:
-              eslint: ["6", "7"]

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "@babel/eslint-parser": "^7",
-    "eslint": "^6 || ^7"
+    "eslint": "^7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When installing this package with eslint@6, the following message gets printed. ([example](https://app.circleci.com/pipelines/github/salesforce/eslint-plugin-lwc/194/workflows/c8b537f0-f57a-47fe-b471-72b1331c5536/jobs/255/parallel-runs/0/steps/0-105))

```
warning " > @babel/eslint-parser@7.13.14" has incorrect peer dependency "eslint@>=7.5.0".
```

This is because @babel/eslint-parser@7 is incompatible with eslint@6. Dropping support for a peerDependency version should be considered as a breaking change. However, since eslint@6 support is already broken today, we should release this as a simple fix.