### PR TITLE
feat: Add no-template-children rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ To choose from three configuration settings, install the [`eslint-config-lwc`](h
 
 ### Best practices
 
-| Rule ID                                                                  | Description                                             | Fixable |
-| ------------------------------------------------------------------------ | ------------------------------------------------------- | ------- |
-| [lwc/no-async-operation](./docs/rules/no-async-operation.md)             | restrict usage of async operations                      |         |
-| [lwc/no-dupe-class-members](./docs/rules/no-dupe-class-members.md)       | disallow duplicate class members                        |         |
-| [lwc/no-inner-html](./docs/rules/no-inner-html.md)                       | disallow usage of `innerHTML`                           |         |
-| [lwc/no-leaky-event-listeners](./docs/rules/no-leaky-event-listeners.md) | prevent event listeners from leaking memory             |         |
-| [lwc/prefer-custom-event](./docs/rules/prefer-custom-event.md)           | suggest usage of `CustomEvent` over `Event` constructor |         |
+| Rule ID                                                                  | Description                                               | Fixable |
+| ------------------------------------------------------------------------ | --------------------------------------------------------- | ------- |
+| [lwc/no-async-operation](./docs/rules/no-async-operation.md)             | restrict usage of async operations                        |         |
+| [lwc/no-dupe-class-members](./docs/rules/no-dupe-class-members.md)       | disallow duplicate class members                          |         |
+| [lwc/no-inner-html](./docs/rules/no-inner-html.md)                       | disallow usage of `innerHTML`                             |         |
+| [lwc/no-template-children](./docs/rules/no-template-children.md)         | prevent accessing the immediate children of this.template |         |
+| [lwc/no-leaky-event-listeners](./docs/rules/no-leaky-event-listeners.md) | prevent event listeners from leaking memory               |         |
+| [lwc/prefer-custom-event](./docs/rules/prefer-custom-event.md)           | suggest usage of `CustomEvent` over `Event` constructor   |         |
 
 ### Compat performance
 

--- a/docs/rules/no-template-children.md
+++ b/docs/rules/no-template-children.md
@@ -26,7 +26,7 @@ export default class Test extends LightningElement {
 In the code above, accessing `firstChild` on `this.template` could return the following results:
 
 -   A `<style>` element in the case of native shadow DOM running on [browsers that do not support constructable stylesheets](https://caniuse.com/mdn-api_shadowroot_adoptedstylesheets).
--   The first element defined in the component's template, if this is synthetic shadow DOM, or this is native shadow DOM and the browser supports constructable stylesheets.
+-   The`<div>` element defined in the component's template, if this is synthetic shadow DOM, or this is native shadow DOM and the browser supports constructable stylesheets.
 
 So the behavior could be different in different browsers, or in native shadow DOM compared to synthetic shadow DOM.
 

--- a/docs/rules/no-template-children.md
+++ b/docs/rules/no-template-children.md
@@ -1,15 +1,19 @@
 ## Prevent accessing the immediate children of this.template (no-template-children)
 
-Directly accessing the Shadow root children elements via `this.template` can produce inconsistent results across browsers and across native and synthetic shadow DOM. This rule prevents accessing these unsafe properties.
+Directly accessing the shadow root children elements via `this.template` can produce inconsistent results across browsers and across native and synthetic shadow DOM. This rule prevents accessing these unsafe properties.
 
 ### Rule details
-In this section, we will assume the `Test` component to use the following template.
 
+Let's assume a `Test` component with the following template:
+
+```html
 <template>
     <div>Find me</div>
 </template>
+```
 
-The `Test` component will have to get a reference on the `<div>` element rendered its shadow tree.
+The `Test` component will have to get a reference to the `<div>` element rendered in its shadow tree.
+
 Example of **incorrect** code:
 
 ```js
@@ -51,4 +55,6 @@ export default class Test extends LightningElement {
 }
 ```
 
-In the example above, we are using `querySelector` to find the element from our template – in this case, a `<div>`. The behavior will not differ between browsers, because the selector will not match any element that isn't a `<div>` element, and this is regardless if the component is running in with native shadow DOM or not. Use whichever selector makes sense for the element you're trying to find.
+In the example above, we are using `querySelector` to find the element from our template – in this case, a `<div>`. The behavior will not differ between browsers, because the selector will not match any element that isn't a `<div>` element, and this is regardless of whether the component is running in native shadow DOM or not.
+
+In your own components, use whichever selector makes sense for the element you're trying to find.

--- a/docs/rules/no-template-children.md
+++ b/docs/rules/no-template-children.md
@@ -30,6 +30,8 @@ The following properties are considered unsafe to access on `this.template`:
 -   `childNodes`
 -   `firstChild`
 -   `firstElementChild`
+-   `lastChild`
+-   `lastElementChild`
 
 Example of **correct** code:
 

--- a/docs/rules/no-template-children.md
+++ b/docs/rules/no-template-children.md
@@ -45,4 +45,4 @@ export default class Test extends LightningElement {
 }
 ```
 
-In the example above, we are using `querySelector` to find the element from our template – in this case, a `<div>`. The behavior will not differ between browsers, because the selector will not match a `<style>` element. Use whichever selector makes sense for the element you're trying to find.
+In the example above, we are using `querySelector` to find the element from our template – in this case, a `<div>`. The behavior will not differ between browsers, because the selector will not match any element that isn't a `<div>` element, and this is regardless if the component is running in with native shadow DOM or not. Use whichever selector makes sense for the element you're trying to find.

--- a/docs/rules/no-template-children.md
+++ b/docs/rules/no-template-children.md
@@ -3,7 +3,13 @@
 Directly accessing the Shadow root children elements via `this.template` can produce inconsistent results across browsers and across native and synthetic shadow DOM. This rule prevents accessing these unsafe properties.
 
 ### Rule details
+In this section, we will assume the `Test` component to use the following template.
 
+<template>
+    <div>Find me</div>
+</template>
+
+The `Test` component will have to get a reference on the `<div>` element rendered its shadow tree.
 Example of **incorrect** code:
 
 ```js

--- a/docs/rules/no-template-children.md
+++ b/docs/rules/no-template-children.md
@@ -1,6 +1,6 @@
 ## Prevent accessing the immediate children of this.template (no-template-children)
 
-Directly querying the children of `this.template` can produce inconsistent results across browsers and across native and synthetic shadow DOM. This rules prevents accessing these unsafe properties.
+Directly accessing the Shadow root children elements via `this.template` can produce inconsistent results across browsers and across native and synthetic shadow DOM. This rule prevents accessing these unsafe properties.
 
 ### Rule details
 

--- a/docs/rules/no-template-children.md
+++ b/docs/rules/no-template-children.md
@@ -1,0 +1,46 @@
+## Prevent accessing the immediate children of this.template (no-template-children)
+
+Directly querying the children of `this.template` can produce inconsistent results across browsers and across native and synthetic shadow DOM. This rules prevents accessing these unsafe properties.
+
+### Rule details
+
+Example of **incorrect** code:
+
+```js
+import { LightningElement } from 'lwc';
+
+export default class Test extends LightningElement {
+    renderedCallback() {
+        const element = this.template.firstChild;
+        //                            ^ Accessing firstChild on this.template is unsafe.
+    }
+}
+```
+
+In the code above, accessing `firstChild` on `this.template` could return the following results:
+
+-   A `<style>` element in the case of native shadow DOM running on [browsers that do not support constructable stylesheets](https://caniuse.com/mdn-api_shadowroot_adoptedstylesheets).
+-   The first element defined in the component's template, if this is synthetic shadow DOM, or this is native shadow DOM and the browser supports constructable stylesheets.
+
+So the behavior could be different in different browsers, or in native shadow DOM compared to synthetic shadow DOM.
+
+The following properties are considered unsafe to access on `this.template`:
+
+-   `children`
+-   `childNodes`
+-   `firstChild`
+-   `firstElementChild`
+
+Example of **correct** code:
+
+```js
+import { LightningElement } from 'lwc';
+
+export default class Test extends LightningElement {
+    renderedCallback() {
+        const element = this.template.querySelector('div'); // Use querySelector instead of firstChild.
+    }
+}
+```
+
+In the example above, we are using `querySelector` to find the element from our template – in this case, a `<div>`. The behavior will not differ between browsers, because the selector will not match a `<style>` element. Use whichever selector makes sense for the element you're trying to find.

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ const rules = {
     'no-inner-html': require('./rules/no-inner-html'),
     'no-leading-uppercase-api-name': require('./rules/no-leading-uppercase-api-name'),
     'no-leaky-event-listeners': require('./rules/no-leaky-event-listeners'),
+    'no-template-children': require('./rules/no-template-children'),
     'no-unexpected-wire-adapter-usages': require('./rules/no-unexpected-wire-adapter-usages'),
     'no-rest-parameter': require('./rules/no-rest-parameter'),
     'no-unknown-wire-adapters': require('./rules/no-unknown-wire-adapters'),

--- a/lib/rules/no-template-children.js
+++ b/lib/rules/no-template-children.js
@@ -23,6 +23,7 @@ const disallowedProperties = new Set([
 function isThisDotTemplateExpression(node) {
     return (
         node.type === 'MemberExpression' &&
+        node.computed === false &&
         node.object.type === 'ThisExpression' &&
         node.property.type === 'Identifier' &&
         node.property.name === 'template'

--- a/lib/rules/no-template-children.js
+++ b/lib/rules/no-template-children.js
@@ -8,7 +8,14 @@
 
 const { docUrl } = require('../util/doc-url');
 
-const disallowedProperties = new Set(['firstElementChild', 'firstChild', 'children', 'childNodes']);
+const disallowedProperties = new Set([
+    'children',
+    'childNodes',
+    'firstChild',
+    'firstElementChild',
+    'lastChild',
+    'lastElementChild',
+]);
 
 /**
  * Returns true if this is a `this.template` expression

--- a/lib/rules/no-template-children.js
+++ b/lib/rules/no-template-children.js
@@ -86,7 +86,7 @@ module.exports = {
                     isThisDotTemplateExpression(parent) &&
                     grandparent.type === 'VariableDeclarator' &&
                     grandparent.id.type === 'ObjectPattern' &&
-                    isThisDotTemplateExpression(grandparent.init) &&
+                    grandparent.init === parent &&
                     grandparent.id.properties.some(propertyIsDisallowedForThisDotTemplate)
                 ) {
                     // E.g.: `const { firstChild } = this.template`
@@ -101,8 +101,7 @@ module.exports = {
                 } else if (
                     parent.type === 'VariableDeclarator' &&
                     parent.id.type === 'ObjectPattern' &&
-                    parent.init &&
-                    parent.init.type === 'ThisExpression' &&
+                    parent.init === node &&
                     parent.id.properties.some(propertyIsDisallowedForThis)
                 ) {
                     // E.g.: `const { template: { firstChild } } = this`

--- a/lib/rules/no-template-children.js
+++ b/lib/rules/no-template-children.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { docUrl } = require('../util/doc-url');
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'prevent accessing the immediate children of this.template',
+            category: 'LWC',
+            recommended: true,
+            url: docUrl('no-template-children'),
+        },
+
+        schema: [],
+    },
+
+    create(context) {
+        const disallowedProperties = ['firstElementChild', 'firstChild', 'children', 'childNodes'];
+
+        /**
+         * Returns true if this is a `this.template` expression
+         */
+        function isThisDotTemplateExpression(node) {
+            return (
+                node.type === 'MemberExpression' &&
+                node.object.type === 'ThisExpression' &&
+                node.property.type === 'Identifier' &&
+                node.property.name === 'template'
+            );
+        }
+
+        /**
+         * Returns true if this is an ObjectExpression property that should be disallowed for `this.template`
+         * E.g.: `const { firstChild } = this.template`
+         */
+        function propertyIsDisallowedForThisDotTemplate(prop) {
+            return prop.key.type === 'Identifier' && disallowedProperties.includes(prop.key.name);
+        }
+
+        /**
+         * Returns true if this is an ObjectExpression property that should be disallowed for `this`
+         * E.g.: `const { template: { firstChild } } = this`
+         */
+        function propertyIsDisallowedForThis(prop) {
+            const { key, value } = prop;
+            return (
+                key.type === 'Identifier' &&
+                key.name === 'template' &&
+                value.type === 'ObjectPattern' &&
+                value.properties.some(propertyIsDisallowedForThisDotTemplate)
+            );
+        }
+
+        return {
+            MemberExpression(node) {
+                const { object, property } = node;
+
+                if (
+                    isThisDotTemplateExpression(object) &&
+                    property.type === 'Identifier' &&
+                    disallowedProperties.includes(property.name)
+                ) {
+                    // E.g.: `const child = this.template.firstChild`
+
+                    context.report({
+                        message: `Accessing ${property.name} on this.template is unsafe`,
+                        node: property,
+                    });
+                }
+            },
+            VariableDeclarator(node) {
+                const { id, init } = node;
+
+                if (
+                    id.type === 'ObjectPattern' &&
+                    isThisDotTemplateExpression(init) &&
+                    id.properties.some(propertyIsDisallowedForThisDotTemplate)
+                ) {
+                    // E.g.: `const { firstChild } = this.template`
+
+                    const property = id.properties.find(propertyIsDisallowedForThisDotTemplate);
+                    context.report({
+                        message: `Accessing ${property.key.name} on this.template is unsafe`,
+                        node: property,
+                    });
+                } else if (
+                    id.type === 'ObjectPattern' &&
+                    init.type === 'ThisExpression' &&
+                    id.properties.some(propertyIsDisallowedForThis)
+                ) {
+                    // E.g.: `const { template: { firstChild } } = this`
+
+                    const thisProperty = id.properties.find(propertyIsDisallowedForThis);
+                    const templateProperty = thisProperty.value.properties.find(
+                        propertyIsDisallowedForThisDotTemplate,
+                    );
+
+                    context.report({
+                        message: `Accessing ${templateProperty.key.name} on this.template is unsafe`,
+                        node: templateProperty,
+                    });
+                }
+            },
+        };
+    },
+};

--- a/lib/rules/no-template-children.js
+++ b/lib/rules/no-template-children.js
@@ -66,46 +66,47 @@ module.exports = {
 
     create(context) {
         return {
-            MemberExpression(node) {
-                const { object, property } = node;
+            ThisExpression(node) {
+                const { parent } = node;
+                const { parent: grandparent } = parent;
 
                 if (
-                    isThisDotTemplateExpression(object) &&
-                    node.computed === false &&
-                    property.type === 'Identifier' &&
-                    disallowedProperties.has(property.name)
+                    isThisDotTemplateExpression(parent) &&
+                    grandparent.type === 'MemberExpression' &&
+                    grandparent.property.type === 'Identifier' &&
+                    disallowedProperties.has(grandparent.property.name)
                 ) {
                     // E.g.: `const child = this.template.firstChild`
 
                     context.report({
-                        message: `Accessing ${property.name} on this.template is unsafe`,
-                        node: property,
+                        message: `Accessing ${grandparent.property.name} on this.template is unsafe`,
+                        node: grandparent.property,
                     });
-                }
-            },
-            VariableDeclarator(node) {
-                const { id, init } = node;
-
-                if (
-                    id.type === 'ObjectPattern' &&
-                    isThisDotTemplateExpression(init) &&
-                    id.properties.some(propertyIsDisallowedForThisDotTemplate)
+                } else if (
+                    isThisDotTemplateExpression(parent) &&
+                    grandparent.type === 'VariableDeclarator' &&
+                    grandparent.id.type === 'ObjectPattern' &&
+                    isThisDotTemplateExpression(grandparent.init) &&
+                    grandparent.id.properties.some(propertyIsDisallowedForThisDotTemplate)
                 ) {
                     // E.g.: `const { firstChild } = this.template`
 
-                    const property = id.properties.find(propertyIsDisallowedForThisDotTemplate);
+                    const property = grandparent.id.properties.find(
+                        propertyIsDisallowedForThisDotTemplate,
+                    );
                     context.report({
                         message: `Accessing ${property.key.name} on this.template is unsafe`,
                         node: property,
                     });
                 } else if (
-                    id.type === 'ObjectPattern' &&
-                    init.type === 'ThisExpression' &&
-                    id.properties.some(propertyIsDisallowedForThis)
+                    parent.type === 'VariableDeclarator' &&
+                    parent.id.type === 'ObjectPattern' &&
+                    parent.init.type === 'ThisExpression' &&
+                    parent.id.properties.some(propertyIsDisallowedForThis)
                 ) {
                     // E.g.: `const { template: { firstChild } } = this`
 
-                    const thisProperty = id.properties.find(propertyIsDisallowedForThis);
+                    const thisProperty = parent.id.properties.find(propertyIsDisallowedForThis);
                     const templateProperty = thisProperty.value.properties.find(
                         propertyIsDisallowedForThisDotTemplate,
                     );

--- a/lib/rules/no-template-children.js
+++ b/lib/rules/no-template-children.js
@@ -101,6 +101,7 @@ module.exports = {
                 } else if (
                     parent.type === 'VariableDeclarator' &&
                     parent.id.type === 'ObjectPattern' &&
+                    parent.init &&
                     parent.init.type === 'ThisExpression' &&
                     parent.id.properties.some(propertyIsDisallowedForThis)
                 ) {

--- a/lib/rules/no-template-children.js
+++ b/lib/rules/no-template-children.js
@@ -8,6 +8,42 @@
 
 const { docUrl } = require('../util/doc-url');
 
+const disallowedProperties = new Set(['firstElementChild', 'firstChild', 'children', 'childNodes']);
+
+/**
+ * Returns true if this is a `this.template` expression
+ */
+function isThisDotTemplateExpression(node) {
+    return (
+        node.type === 'MemberExpression' &&
+        node.object.type === 'ThisExpression' &&
+        node.property.type === 'Identifier' &&
+        node.property.name === 'template'
+    );
+}
+
+/**
+ * Returns true if this is an ObjectExpression property that should be disallowed for `this.template`
+ * E.g.: `const { firstChild } = this.template`
+ */
+function propertyIsDisallowedForThisDotTemplate(prop) {
+    return prop.key.type === 'Identifier' && disallowedProperties.has(prop.key.name);
+}
+
+/**
+ * Returns true if this is an ObjectExpression property that should be disallowed for `this`
+ * E.g.: `const { template: { firstChild } } = this`
+ */
+function propertyIsDisallowedForThis(prop) {
+    const { key, value } = prop;
+    return (
+        key.type === 'Identifier' &&
+        key.name === 'template' &&
+        value.type === 'ObjectPattern' &&
+        value.properties.some(propertyIsDisallowedForThisDotTemplate)
+    );
+}
+
 module.exports = {
     meta: {
         docs: {
@@ -21,42 +57,6 @@ module.exports = {
     },
 
     create(context) {
-        const disallowedProperties = ['firstElementChild', 'firstChild', 'children', 'childNodes'];
-
-        /**
-         * Returns true if this is a `this.template` expression
-         */
-        function isThisDotTemplateExpression(node) {
-            return (
-                node.type === 'MemberExpression' &&
-                node.object.type === 'ThisExpression' &&
-                node.property.type === 'Identifier' &&
-                node.property.name === 'template'
-            );
-        }
-
-        /**
-         * Returns true if this is an ObjectExpression property that should be disallowed for `this.template`
-         * E.g.: `const { firstChild } = this.template`
-         */
-        function propertyIsDisallowedForThisDotTemplate(prop) {
-            return prop.key.type === 'Identifier' && disallowedProperties.includes(prop.key.name);
-        }
-
-        /**
-         * Returns true if this is an ObjectExpression property that should be disallowed for `this`
-         * E.g.: `const { template: { firstChild } } = this`
-         */
-        function propertyIsDisallowedForThis(prop) {
-            const { key, value } = prop;
-            return (
-                key.type === 'Identifier' &&
-                key.name === 'template' &&
-                value.type === 'ObjectPattern' &&
-                value.properties.some(propertyIsDisallowedForThisDotTemplate)
-            );
-        }
-
         return {
             MemberExpression(node) {
                 const { object, property } = node;
@@ -64,7 +64,7 @@ module.exports = {
                 if (
                     isThisDotTemplateExpression(object) &&
                     property.type === 'Identifier' &&
-                    disallowedProperties.includes(property.name)
+                    disallowedProperties.has(property.name)
                 ) {
                     // E.g.: `const child = this.template.firstChild`
 

--- a/lib/rules/no-template-children.js
+++ b/lib/rules/no-template-children.js
@@ -71,6 +71,7 @@ module.exports = {
 
                 if (
                     isThisDotTemplateExpression(object) &&
+                    node.computed === false &&
                     property.type === 'Identifier' &&
                     disallowedProperties.has(property.name)
                 ) {

--- a/test/lib/rules/no-template-children.js
+++ b/test/lib/rules/no-template-children.js
@@ -74,6 +74,10 @@ const validCases = [
     {
         code: `const firstChild = this[template].firstChild;`,
     },
+    // check we don't get an undefined/null error for checking the node parent/grandparent
+    {
+        code: 'this',
+    },
     ...buildCases({
         properties: [
             'getElementById',

--- a/test/lib/rules/no-template-children.js
+++ b/test/lib/rules/no-template-children.js
@@ -55,19 +55,19 @@ const styles = [
 ];
 
 const invalidCases = buildCases({
-    properties: ['children', 'childNodes', 'firstChild', 'firstElementChild'],
+    properties: [
+        'children',
+        'childNodes',
+        'firstChild',
+        'firstElementChild',
+        'lastChild',
+        'lastElementChild',
+    ],
     styles,
 });
 
 const validCases = buildCases({
-    properties: [
-        'getElementById',
-        'getElementsByClassName',
-        'lastChild',
-        'lastElementChild',
-        'querySelector',
-        'querySelectorAll',
-    ],
+    properties: ['getElementById', 'getElementsByClassName', 'querySelector', 'querySelectorAll'],
     styles,
 });
 

--- a/test/lib/rules/no-template-children.js
+++ b/test/lib/rules/no-template-children.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { RuleTester } = require('eslint');
+
+const { ESLINT_TEST_CONFIG } = require('../shared');
+const rule = require('../../../lib/rules/no-template-children');
+
+const ruleTester = new RuleTester(ESLINT_TEST_CONFIG);
+
+function makeCode(property, style) {
+    switch (style) {
+        case 'direct':
+            return `const foo = this.template.${property};`;
+        case 'destructuring':
+            return `const { ${property} } = this.template;`;
+        case 'destructuring-rename':
+            return `const { ${property}: foo } = this.template;`;
+        case 'destructuring-on-this':
+            return `const { template: { ${property} } } = this;`;
+        case 'destructuring-on-this-rename':
+            return `const { template: { ${property}: foo } } = this;`;
+    }
+}
+
+function buildCases({ properties, styles }) {
+    const cases = [];
+    for (const property of properties) {
+        for (const style of styles) {
+            cases.push({
+                code: makeCode(property, style),
+                errors: [
+                    {
+                        message: new RegExp(`Accessing ${property} on this\\.template is unsafe`),
+                    },
+                ],
+            });
+        }
+    }
+
+    return cases;
+}
+
+const styles = [
+    'direct',
+    'destructuring',
+    'destructuring-rename',
+    'destructuring-on-this',
+    'destructuring-on-this-rename',
+];
+
+const invalidCases = buildCases({
+    properties: ['children', 'childNodes', 'firstChild', 'firstElementChild'],
+    styles,
+});
+
+const validCases = buildCases({
+    properties: [
+        'getElementById',
+        'getElementsByClassName',
+        'lastChild',
+        'lastElementChild',
+        'querySelector',
+        'querySelectorAll',
+    ],
+    styles,
+});
+
+ruleTester.run('no-template-children', rule, {
+    valid: validCases,
+    invalid: invalidCases,
+});

--- a/test/lib/rules/no-template-children.js
+++ b/test/lib/rules/no-template-children.js
@@ -66,10 +66,24 @@ const invalidCases = buildCases({
     styles,
 });
 
-const validCases = buildCases({
-    properties: ['getElementById', 'getElementsByClassName', 'querySelector', 'querySelectorAll'],
-    styles,
-});
+const validCases = [
+    // `this[template]` is valid, `this.template` is not
+    {
+        code: `const { firstChild } = this[template];`,
+    },
+    {
+        code: `const firstChild = this[template].firstChild;`,
+    },
+    ...buildCases({
+        properties: [
+            'getElementById',
+            'getElementsByClassName',
+            'querySelector',
+            'querySelectorAll',
+        ],
+        styles,
+    }).map(({ code }) => ({ code })),
+];
 
 ruleTester.run('no-template-children', rule, {
     valid: validCases,


### PR DESCRIPTION
Adds a rule to check for patterns like `this.template.firstChild`, which is commonly used today in shadow-DOM-using code to check whether the component has rendered yet (e.g. `if (!this.template.firstChild) { /* ... */ }`), or to retrieve the first element defined in the template HTML.

This will not work in native shadow DOM in certain browsers, as described in the added docs. `this.template.querySelector` is encouraged as an alternative.

W-9742708