### PR TITLE
chore: Deprecate `no-dupe-class-member` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,9 @@ Older browsers like IE11 run LWC in compatibility mode. For more information abo
 | [lwc/no-async-await](./docs/rules/no-async-await.md)       | disallow usage of the async-await syntax    |         |
 | [lwc/no-for-of](./docs/rules/no-for-of.md)                 | disallow usage of the for-of syntax         |         |
 | [lwc/no-rest-parameter](./docs/rules/no-rest-parameter.md) | disallow usage of the rest parameter syntax |         |
+
+### Deprecated
+
+| Rule ID                                                            | Replaced by                                                                  |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| [lwc/no-dupe-class-members](./docs/rules/no-dupe-class-members.md) | [no-dupe-class-members](https://eslint.org/docs/rules/no-dupe-class-members) |

--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -1,8 +1,8 @@
 # Disallow duplicate class members (no-dupe-class-members)
 
-If there are declarations of the same name in class members, the last declaration overwrites other declarations silently. This can cause unexpected behaviors. This rule prevents usage of duplicate class members (fields and methods) on the same class.
+> ⚠️ This rule is deprecated. It can be replaced by ESLint builtin [no-dupe-class-members](https://eslint.org/docs/rules/no-dupe-class-members) rule. ⚠️
 
-> Note: This rule extends the original eslint rule [`no-dupe-class-members`](https://eslint.org/docs/rules/no-dupe-class-members) to add support for [class fields](https://github.com/tc39/proposal-class-fields) that are not yet stage 4.
+If there are declarations of the same name in class members, the last declaration overwrites other declarations silently. This can cause unexpected behaviors. This rule prevents usage of duplicate class members (fields and methods) on the same class.
 
 ## Rule details
 

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -24,6 +24,9 @@ module.exports = {
         messages: {
             unexpected: "Duplicate name '{{name}}'.",
         },
+
+        deprecated: true,
+        replacedBy: ['no-dupe-class-members'],
     },
 
     create(context) {

--- a/test/lib/rules/no-dupe-class-members.js
+++ b/test/lib/rules/no-dupe-class-members.js
@@ -8,12 +8,18 @@
 
 const semver = require('semver');
 const eslint = require('eslint');
+const assert = require('assert');
+
 const { ESLINT_TEST_CONFIG } = require('../shared');
 const rule = require('../../../lib/rules/no-dupe-class-members');
 
 const ruleTester = new eslint.RuleTester(ESLINT_TEST_CONFIG);
 
 const isEslint7 = semver.satisfies(eslint.ESLint.version, '^7');
+
+it('no-dupe-class-member should be deprecated', () => {
+    assert.equal(rule.meta.deprecated, true);
+});
 
 ruleTester.run('no-dupe-class-members', rule, {
     valid: [


### PR DESCRIPTION
Fixes #80.