### PR TITLE
feat: add no-disallowed-lwc-imports rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ To choose from three configuration settings, install the [`eslint-config-lwc`](h
 | [lwc/no-deprecated](./docs/rules/no-deprecated.md)                                         | disallow usage of deprecated LWC APIs                             |         |
 | [lwc/no-document-query](./docs/rules/no-document-query.md)                                 | disallow DOM query at the document level                          |         |
 | [lwc/no-attributes-during-construction](./docs/rules/no-attributes-during-construction.md) | disallow setting attributes during construction                   |         |
+| [lwc/no-disallowed-lwc-imports](./docs/rules/no-disallowed-lwc-imports.md)                 | disallow importing unsupported APIs from the `lwc` package        |         |
 | [lwc/no-leading-uppercase-api-name](./docs/rules/no-leading-uppercase-api-name.md)         | ensure public property doesn't start with an upper-case character |         |
 | [lwc/no-unexpected-wire-adapter-usages](./docs/rules/no-unexpected-wire-adapter-usages.md) | enforce wire adapters to be used with `wire` decorator            |         |
 | [lwc/no-unknown-wire-adapters](./docs/rules/no-unknown-wire-adapters.md)                   | disallow usage of unknown wire adapters                           |         |

--- a/docs/rules/no-disallowed-lwc-imports.md
+++ b/docs/rules/no-disallowed-lwc-imports.md
@@ -1,0 +1,41 @@
+## Prevent importing restricted APIs from the "lwc" package (no-disallowed-lwc-imports)
+
+Restricts importing disallowed modules from the `lwc` package. It's recommended to only use the "safe" APIs allowed by this rule.
+
+This rule also disallows default imports as well as bare imports and exports – only importing explicitly named modules is allowed.
+
+### Rule details
+
+Examples of **incorrect** code:
+
+```js
+import { SecretApiYouShouldNotUse } from 'lwc';
+```
+
+```js
+import * as lwc from 'lwc';
+```
+
+```js
+import lwc from 'lwc';
+```
+
+```js
+import 'lwc';
+```
+
+```js
+export * from 'lwc';
+```
+
+Examples of **correct** code:
+
+```js
+import { LightningElement } from 'lwc';
+```
+
+```js
+import { LightningElement, wire, api } from 'lwc';
+```
+
+If you disable this rule, then you may import unstable or otherwise undesirable APIs from `lwc`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ const rules = {
     'no-inner-html': require('./rules/no-inner-html'),
     'no-leading-uppercase-api-name': require('./rules/no-leading-uppercase-api-name'),
     'no-leaky-event-listeners': require('./rules/no-leaky-event-listeners'),
+    'no-disallowed-lwc-imports': require('./rules/no-disallowed-lwc-imports'),
     'no-template-children': require('./rules/no-template-children'),
     'no-unexpected-wire-adapter-usages': require('./rules/no-unexpected-wire-adapter-usages'),
     'no-rest-parameter': require('./rules/no-rest-parameter'),

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -85,6 +85,28 @@ module.exports = {
                     }
                 }
             },
+            ExportNamedDeclaration(node) {
+                if (isLwcImport(node)) {
+                    const { specifiers } = node;
+                    if (!specifiers.length) {
+                        // import 'lwc'
+                        context.report({
+                            message: `Invalid export. Bare exports are not allowed on "lwc". Instead, use named exports: "export { LightningElement } from 'lwc'".`,
+                            node,
+                        });
+                    }
+                    for (const specifier of specifiers) {
+                        const { type, local } = specifier;
+                        if (type === 'ExportSpecifier' && !LWC_SUPPORTED_APIS.has(local.name)) {
+                            // import { fake } from 'lwc'
+                            context.report({
+                                message: `Invalid export. "${local.name}" is not a known and stable API.`,
+                                node: specifier,
+                            });
+                        }
+                    }
+                }
+            },
             ExportAllDeclaration(node) {
                 if (isLwcImport(node)) {
                     // export * from 'lwc'

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -89,7 +89,7 @@ module.exports = {
                 if (isLwcImport(node)) {
                     const { specifiers } = node;
                     if (!specifiers.length) {
-                        // import 'lwc'
+                        // export 'lwc'
                         context.report({
                             message: `Invalid export. Bare exports are not allowed on "lwc". Instead, use named exports: "export { LightningElement } from 'lwc'".`,
                             node,

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -69,7 +69,7 @@ module.exports = {
                         } else if (type === 'ImportDefaultSpecifier') {
                             // import lwc from 'lwc'
                             context.report({
-                                message: `Invalid import. "lwc" does not export a default module. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                                message: `Invalid import. "lwc" does not have a default export. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
                                 node: specifier,
                             });
                         } else if (

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { docUrl } = require('../util/doc-url');
+
+const LWC_SUPPORTED_APIS = new Set([
+    // Common APIs
+    'LightningElement',
+    'api',
+    'track',
+    'wire',
+
+    // From "@lwc/engine-core"
+    'getComponentDef',
+    'getComponentConstructor',
+    'isComponentConstructor',
+    'createContextProvider',
+    'readonly',
+    'register',
+    'setFeatureFlagForTest',
+    'unwrap',
+
+    // From "@lwc/engine-dom"
+    'hydrateComponent',
+    'buildCustomElementConstructor',
+    'createElement',
+
+    // From "@lwc/engine-server"
+    'renderComponent',
+]);
+
+const isLwcImport = (node) => node.source.type === 'Literal' && node.source.value === 'lwc';
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'restrict unexpected imports from the lwc package',
+            category: 'LWC',
+            url: docUrl('no-disallowed-lwc-imports'),
+        },
+        schema: [],
+    },
+
+    create(context) {
+        return {
+            ImportDeclaration(node) {
+                if (isLwcImport(node)) {
+                    const { specifiers } = node;
+                    if (!specifiers.length) {
+                        // import 'lwc'
+                        context.report({
+                            message: `Invalid import. Bare imports are not allowed on "lwc". Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                            node,
+                        });
+                    }
+                    for (const specifier of specifiers) {
+                        const { type, imported } = specifier;
+                        if (type === 'ImportNamespaceSpecifier') {
+                            // import * as lwc from 'lwc'
+                            context.report({
+                                message: `Invalid import. Namespace imports are not allowed on "lwc". Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                                node: specifier,
+                            });
+                        } else if (type === 'ImportDefaultSpecifier') {
+                            // import lwc from 'lwc'
+                            context.report({
+                                message: `Invalid import. "lwc" does not export a default module. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                                node: specifier,
+                            });
+                        } else if (
+                            type === 'ImportSpecifier' &&
+                            !LWC_SUPPORTED_APIS.has(imported.name)
+                        ) {
+                            // import { fake } from 'lwc'
+                            context.report({
+                                message: `Invalid import. ${imported.name} is not part of the lwc api.`,
+                                node: specifier,
+                            });
+                        }
+                    }
+                }
+            },
+            ExportAllDeclaration(node) {
+                if (isLwcImport(node)) {
+                    // export * from 'lwc'
+                    context.report({
+                        message: `Invalid export. Exporting from "lwc" is not allowed. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                        node,
+                    });
+                }
+            },
+        };
+    },
+};

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -78,7 +78,7 @@ module.exports = {
                         ) {
                             // import { fake } from 'lwc'
                             context.report({
-                                message: `Invalid import. ${imported.name} is not part of the lwc api.`,
+                                message: `Invalid import. "${imported.name}" is not a known and stable API.`,
                                 node: specifier,
                             });
                         }

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -89,7 +89,7 @@ module.exports = {
                 if (isLwcImport(node)) {
                     // export * from 'lwc'
                     context.report({
-                        message: `Invalid export. Exporting from "lwc" is not allowed. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                        message: `Invalid export. Exporting from "lwc" is not allowed.`,
                         node,
                     });
                 }

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -98,7 +98,7 @@ module.exports = {
                     for (const specifier of specifiers) {
                         const { type, local } = specifier;
                         if (type === 'ExportSpecifier' && !LWC_SUPPORTED_APIS.has(local.name)) {
-                            // import { fake } from 'lwc'
+                            // export { fake } from 'lwc'
                             context.report({
                                 message: `Invalid export. "${local.name}" is not a known and stable API.`,
                                 node: specifier,

--- a/test/lib/rules/no-disallowed-lwc-imports.js
+++ b/test/lib/rules/no-disallowed-lwc-imports.js
@@ -18,7 +18,9 @@ const invalidCases = [
         code: `import { ShouldNotImport } from "lwc"`,
         errors: [
             {
-                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+                message: new RegExp(
+                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                ),
             },
         ],
     },
@@ -26,7 +28,9 @@ const invalidCases = [
         code: `import { ShouldNotImport as LightningElement } from "lwc"`,
         errors: [
             {
-                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+                message: new RegExp(
+                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                ),
             },
         ],
     },
@@ -34,7 +38,9 @@ const invalidCases = [
         code: `import { ShouldNotImport, LightningElement } from "lwc"`,
         errors: [
             {
-                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+                message: new RegExp(
+                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                ),
             },
         ],
     },
@@ -42,7 +48,9 @@ const invalidCases = [
         code: `import { LightningElement, ShouldNotImport } from "lwc"`,
         errors: [
             {
-                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+                message: new RegExp(
+                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                ),
             },
         ],
     },
@@ -50,10 +58,12 @@ const invalidCases = [
         code: `import { ShouldNotImport, AlsoBanned } from "lwc"`,
         errors: [
             {
-                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+                message: new RegExp(
+                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                ),
             },
             {
-                message: new RegExp(`Invalid import. AlsoBanned is not part of the lwc api.`),
+                message: new RegExp(`Invalid import. "AlsoBanned" is not a known and stable API.`),
             },
         ],
     },
@@ -61,10 +71,12 @@ const invalidCases = [
         code: `import { LightningElement, ShouldNotImport, AlsoBanned } from "lwc"`,
         errors: [
             {
-                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+                message: new RegExp(
+                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                ),
             },
             {
-                message: new RegExp(`Invalid import. AlsoBanned is not part of the lwc api.`),
+                message: new RegExp(`Invalid import. "AlsoBanned" is not a known and stable API.`),
             },
         ],
     },
@@ -82,9 +94,7 @@ const invalidCases = [
         code: `export * from 'lwc'`,
         errors: [
             {
-                message: new RegExp(
-                    `Invalid export. Exporting from "lwc" is not allowed. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
-                ),
+                message: new RegExp(`Invalid export. Exporting from "lwc" is not allowed.`),
             },
         ],
     },
@@ -92,9 +102,7 @@ const invalidCases = [
         code: `export * as foo from 'lwc'`,
         errors: [
             {
-                message: new RegExp(
-                    `Invalid export. Exporting from "lwc" is not allowed. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
-                ),
+                message: new RegExp(`Invalid export. Exporting from "lwc" is not allowed.`),
             },
         ],
     },
@@ -102,9 +110,7 @@ const invalidCases = [
         code: `import 'lwc'`,
         errors: [
             {
-                message: new RegExp(
-                    `Invalid import. Bare imports are not allowed on "lwc". Instead, use named imports: "import { LightningElement } from 'lwc'".`,
-                ),
+                message: new RegExp(`Invalid import. Bare imports are not allowed on "lwc".`),
             },
         ],
     },

--- a/test/lib/rules/no-disallowed-lwc-imports.js
+++ b/test/lib/rules/no-disallowed-lwc-imports.js
@@ -134,6 +134,82 @@ const invalidCases = [
             },
         ],
     },
+    {
+        code: `export { ShouldNotImport } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `export { ShouldNotImport as LightningElement } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `export { ShouldNotImport, LightningElement } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `export { LightningElement, ShouldNotImport } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `export { ShouldNotImport, AlsoBanned } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                ),
+            },
+            {
+                message: new RegExp(`Invalid export. "AlsoBanned" is not a known and stable API.`),
+            },
+        ],
+    },
+    {
+        code: `export { LightningElement, ShouldNotImport, AlsoBanned } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                ),
+            },
+            {
+                message: new RegExp(`Invalid export. "AlsoBanned" is not a known and stable API.`),
+            },
+        ],
+    },
+    {
+        code: `export {} from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid export. Bare exports are not allowed on "lwc". Instead, use named exports: "export { LightningElement } from 'lwc'".`,
+                ),
+            },
+        ],
+    },
 ];
 
 const validCases = [
@@ -163,6 +239,24 @@ const validCases = [
     },
     {
         code: `export * from "some-other-package"`,
+    },
+    {
+        code: `export { foo } from "some-other-package"`,
+    },
+    {
+        code: `export { LightningElement } from "lwc"`,
+    },
+    {
+        code: `export { LightningElement, wire } from "lwc"`,
+    },
+    {
+        code: `export { LightningElement, wire, api } from "lwc"`,
+    },
+    {
+        code: `export { LightningElement as Yolo } from "lwc"`,
+    },
+    {
+        code: `export {} from "some-other-package"`,
     },
 ];
 

--- a/test/lib/rules/no-disallowed-lwc-imports.js
+++ b/test/lib/rules/no-disallowed-lwc-imports.js
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const { RuleTester } = require('eslint');
+
+const { ESLINT_TEST_CONFIG } = require('../shared');
+const rule = require('../../../lib/rules/no-disallowed-lwc-imports');
+
+const ruleTester = new RuleTester(ESLINT_TEST_CONFIG);
+
+const invalidCases = [
+    {
+        code: `import { ShouldNotImport } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+            },
+        ],
+    },
+    {
+        code: `import { ShouldNotImport as LightningElement } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+            },
+        ],
+    },
+    {
+        code: `import { ShouldNotImport, LightningElement } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+            },
+        ],
+    },
+    {
+        code: `import { LightningElement, ShouldNotImport } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+            },
+        ],
+    },
+    {
+        code: `import { ShouldNotImport, AlsoBanned } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+            },
+            {
+                message: new RegExp(`Invalid import. AlsoBanned is not part of the lwc api.`),
+            },
+        ],
+    },
+    {
+        code: `import { LightningElement, ShouldNotImport, AlsoBanned } from "lwc"`,
+        errors: [
+            {
+                message: new RegExp(`Invalid import. ShouldNotImport is not part of the lwc api.`),
+            },
+            {
+                message: new RegExp(`Invalid import. AlsoBanned is not part of the lwc api.`),
+            },
+        ],
+    },
+    {
+        code: `import * as lwc from 'lwc'`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid import. Namespace imports are not allowed on "lwc". Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `export * from 'lwc'`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid export. Exporting from "lwc" is not allowed. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `export * as foo from 'lwc'`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid export. Exporting from "lwc" is not allowed. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `import 'lwc'`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid import. Bare imports are not allowed on "lwc". Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `import lwc from 'lwc'`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid import. "lwc" does not export a default module. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `import lwc, { LightningElement } from 'lwc'`,
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid import. "lwc" does not export a default module. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                ),
+            },
+        ],
+    },
+];
+
+const validCases = [
+    {
+        code: `import { LightningElement } from "lwc"`,
+    },
+    {
+        code: `import { LightningElement, wire } from "lwc"`,
+    },
+    {
+        code: `import { LightningElement, wire, api } from "lwc"`,
+    },
+    {
+        code: `import { LightningElement as Yolo } from "lwc"`,
+    },
+    {
+        code: `import "some-other-package"`,
+    },
+    {
+        code: `import * as foo from "some-other-package"`,
+    },
+    {
+        code: `import { foo } from "some-other-package"`,
+    },
+    {
+        code: `export * as foo from "some-other-package"`,
+    },
+    {
+        code: `export * from "some-other-package"`,
+    },
+];
+
+ruleTester.run('no-disallowed-lwc-imports', rule, {
+    valid: validCases,
+    invalid: invalidCases,
+});

--- a/test/lib/rules/no-disallowed-lwc-imports.js
+++ b/test/lib/rules/no-disallowed-lwc-imports.js
@@ -113,7 +113,7 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid import. "lwc" does not export a default module. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                    `Invalid import. "lwc" does not have a default export. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
                 ),
             },
         ],
@@ -123,7 +123,7 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid import. "lwc" does not export a default module. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                    `Invalid import. "lwc" does not have a default export. Instead, use named imports: "import { LightningElement } from 'lwc'".`,
                 ),
             },
         ],

--- a/test/lib/rules/no-disallowed-lwc-imports.js
+++ b/test/lib/rules/no-disallowed-lwc-imports.js
@@ -258,6 +258,9 @@ const validCases = [
     {
         code: `export {} from "some-other-package"`,
     },
+    {
+        code: `export { LightningElement as default } from "lwc"`,
+    },
 ];
 
 ruleTester.run('no-disallowed-lwc-imports', rule, {


### PR DESCRIPTION
Fixes: https://github.com/salesforce/lwc/issues/1284 and W-10151021

Adds a rule to disallow restricted APIs from the `lwc` package.