### PR TITLE
chore: upgrade minimatch to resolve security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prettier": "^2.3.2"
   },
   "dependencies": {
-    "minimatch": "^3.0.4"
+    "minimatch": "^3.0.5"
   },
   "peerDependencies": {
     "@babel/eslint-parser": "^7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1698,6 +1698,13 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.0.5:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"


### PR DESCRIPTION
PR #2, backport to spring22/236.

Issue described here:
https://www.huntr.dev/bounties/e4e1393c-d590-4492-9f43-8be3f3321629/