### PR TITLE
fix: fix named variable/function exports

### DIFF
--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -34,7 +34,8 @@ const LWC_SUPPORTED_APIS = new Set([
     'renderComponent',
 ]);
 
-const isLwcImport = (node) => node.source.type === 'Literal' && node.source.value === 'lwc';
+const isLwcImport = (node) =>
+    node.source && node.source.type === 'Literal' && node.source.value === 'lwc';
 
 module.exports = {
     meta: {

--- a/test/lib/rules/no-disallowed-lwc-imports.js
+++ b/test/lib/rules/no-disallowed-lwc-imports.js
@@ -261,6 +261,21 @@ const validCases = [
     {
         code: `export { LightningElement as default } from "lwc"`,
     },
+    {
+        code: `export function foo() {}`,
+    },
+    {
+        code: `export default function () {}`,
+    },
+    {
+        code: `export default function foo() {}`,
+    },
+    {
+        code: `export const foo = 'foo'`,
+    },
+    {
+        code: `export default 'foo'`,
+    },
 ];
 
 ruleTester.run('no-disallowed-lwc-imports', rule, {


### PR DESCRIPTION
When trying to release into `eslint-config-lwc`, I noticed a bug in the `no-disallowed-lwc-imports` rule. It fails on code like this:

```js
export function foo() {}
```
```js
export const foo = 'foo'
```

This throws `TypeError: Cannot read properties of null (reading 'type')` at this line:

https://github.com/salesforce/eslint-plugin-lwc/blob/6128fbe36a262b12a8e66d9d3d2a2a902ea4afde/lib/rules/no-disallowed-lwc-imports.js#L37

The problem is that we weren't distinguishing these usages from exports like `export { foo } from 'lwc'`.

This PR fixes that.