### PR TITLE
Add allowList option to `no-disallowed-lwc-imports`

### DIFF
--- a/docs/rules/no-disallowed-lwc-imports.md
+++ b/docs/rules/no-disallowed-lwc-imports.md
@@ -39,3 +39,21 @@ import { LightningElement, wire, api } from 'lwc';
 ```
 
 If you disable this rule, then you may import unstable or otherwise undesirable APIs from `lwc`.
+
+### `allowList`
+
+The `allowList` property overrides the default list of APIs that could be imported from the `lwc` package. It accepts an array of strings.
+
+Examples of **incorrect** code:
+
+```js
+/* eslint lwc/valid-api: ["error", { "allowList": ["LightningElement"] }] */
+import { wire } from 'lwc';
+```
+
+Examples of **correct** code:
+
+```js
+/* eslint lwc/valid-api: ["error", { "allowList": ["LightningElement"] }] */
+import { LightningElement } from 'lwc';
+```

--- a/docs/rules/no-disallowed-lwc-imports.md
+++ b/docs/rules/no-disallowed-lwc-imports.md
@@ -40,20 +40,20 @@ import { LightningElement, wire, api } from 'lwc';
 
 If you disable this rule, then you may import unstable or otherwise undesirable APIs from `lwc`.
 
-### `allowList`
+### `allowlist`
 
-The `allowList` property overrides the default list of APIs that could be imported from the `lwc` package. It accepts an array of strings.
+The `allowlist` property overrides the default list of APIs that could be imported from the `lwc` package. It accepts an array of strings.
 
 Examples of **incorrect** code:
 
 ```js
-/* eslint lwc/valid-api: ["error", { "allowList": ["LightningElement"] }] */
+/* eslint lwc/valid-api: ["error", { "allowlist": ["LightningElement"] }] */
 import { wire } from 'lwc';
 ```
 
 Examples of **correct** code:
 
 ```js
-/* eslint lwc/valid-api: ["error", { "allowList": ["LightningElement"] }] */
+/* eslint lwc/valid-api: ["error", { "allowlist": ["LightningElement"] }] */
 import { LightningElement } from 'lwc';
 ```

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -44,10 +44,30 @@ module.exports = {
             category: 'LWC',
             url: docUrl('no-disallowed-lwc-imports'),
         },
-        schema: [],
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    allowList: {
+                        type: 'array',
+                        items: {
+                            type: 'string',
+                        },
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
     },
 
     create(context) {
+        // Use the API allow list provided by option to the ESLint rule, otherwise fallback to the
+        // default one.
+        let lwcAllowedApis = LWC_SUPPORTED_APIS;
+        if (context.options.length > 0 && context.options[0].allowList) {
+            lwcAllowedApis = new Set(context.options[0].allowList);
+        }
+
         return {
             ImportDeclaration(node) {
                 if (isLwcImport(node)) {
@@ -75,11 +95,11 @@ module.exports = {
                             });
                         } else if (
                             type === 'ImportSpecifier' &&
-                            !LWC_SUPPORTED_APIS.has(imported.name)
+                            !lwcAllowedApis.has(imported.name)
                         ) {
                             // import { fake } from 'lwc'
                             context.report({
-                                message: `Invalid import. "${imported.name}" is not a known and stable API.`,
+                                message: `Invalid import. "${imported.name}" can't be imported from "lwc".`,
                                 node: specifier,
                             });
                         }
@@ -98,10 +118,10 @@ module.exports = {
                     }
                     for (const specifier of specifiers) {
                         const { type, local } = specifier;
-                        if (type === 'ExportSpecifier' && !LWC_SUPPORTED_APIS.has(local.name)) {
+                        if (type === 'ExportSpecifier' && !lwcAllowedApis.has(local.name)) {
                             // export { fake } from 'lwc'
                             context.report({
-                                message: `Invalid export. "${local.name}" is not a known and stable API.`,
+                                message: `Invalid export. "${local.name}" can't be imported from "lwc".`,
                                 node: specifier,
                             });
                         }

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -48,7 +48,7 @@ module.exports = {
             {
                 type: 'object',
                 properties: {
-                    allowList: {
+                    allowlist: {
                         type: 'array',
                         items: {
                             type: 'string',
@@ -64,8 +64,8 @@ module.exports = {
         // Use the API allow list provided by option to the ESLint rule, otherwise fallback to the
         // default one.
         let lwcAllowedApis = LWC_SUPPORTED_APIS;
-        if (context.options.length > 0 && context.options[0].allowList) {
-            lwcAllowedApis = new Set(context.options[0].allowList);
+        if (context.options.length > 0 && context.options[0].allowlist) {
+            lwcAllowedApis = new Set(context.options[0].allowlist);
         }
 
         return {

--- a/test/lib/rules/no-disallowed-lwc-imports.js
+++ b/test/lib/rules/no-disallowed-lwc-imports.js
@@ -215,7 +215,7 @@ const invalidCases = [
         code: `import { LightningElement } from "lwc"`,
         options: [
             {
-                allowList: [],
+                allowlist: [],
             },
         ],
         errors: [
@@ -230,7 +230,7 @@ const invalidCases = [
         code: `export { LightningElement } from "lwc"`,
         options: [
             {
-                allowList: [],
+                allowlist: [],
             },
         ],
         errors: [
@@ -245,7 +245,7 @@ const invalidCases = [
         code: `import { api } from "lwc"`,
         options: [
             {
-                allowList: ['LightningElement'],
+                allowlist: ['LightningElement'],
             },
         ],
         errors: [
@@ -258,7 +258,7 @@ const invalidCases = [
         code: `import { Unknown as LightningElement } from "lwc"`,
         options: [
             {
-                allowList: ['LightningElement'],
+                allowlist: ['LightningElement'],
             },
         ],
         errors: [
@@ -271,7 +271,7 @@ const invalidCases = [
         code: `export { api } from "lwc"`,
         options: [
             {
-                allowList: ['LightningElement'],
+                allowlist: ['LightningElement'],
             },
         ],
         errors: [
@@ -284,7 +284,7 @@ const invalidCases = [
         code: `export { Unknown as LightningElement } from "lwc"`,
         options: [
             {
-                allowList: ['LightningElement'],
+                allowlist: ['LightningElement'],
             },
         ],
         errors: [
@@ -364,7 +364,7 @@ const validCases = [
         code: `import { LightningElement } from "lwc"`,
         options: [
             {
-                allowList: ['LightningElement', 'api'],
+                allowlist: ['LightningElement', 'api'],
             },
         ],
     },
@@ -372,7 +372,7 @@ const validCases = [
         code: `import { LightningElement as LWCElement } from "lwc"`,
         options: [
             {
-                allowList: ['LightningElement', 'api'],
+                allowlist: ['LightningElement', 'api'],
             },
         ],
     },
@@ -380,7 +380,7 @@ const validCases = [
         code: `import { LightningElement, api } from "lwc"`,
         options: [
             {
-                allowList: ['LightningElement', 'api'],
+                allowlist: ['LightningElement', 'api'],
             },
         ],
     },
@@ -388,7 +388,7 @@ const validCases = [
         code: `export  { LightningElement } from "lwc"`,
         options: [
             {
-                allowList: ['LightningElement', 'api'],
+                allowlist: ['LightningElement', 'api'],
             },
         ],
     },
@@ -396,7 +396,7 @@ const validCases = [
         code: `export  { LightningElement, api } from "lwc"`,
         options: [
             {
-                allowList: ['LightningElement', 'api'],
+                allowlist: ['LightningElement', 'api'],
             },
         ],
     },

--- a/test/lib/rules/no-disallowed-lwc-imports.js
+++ b/test/lib/rules/no-disallowed-lwc-imports.js
@@ -19,7 +19,7 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid import. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
         ],
@@ -29,7 +29,7 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid import. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
         ],
@@ -39,7 +39,7 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid import. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
         ],
@@ -49,7 +49,7 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid import. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
         ],
@@ -59,11 +59,11 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid import. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
             {
-                message: new RegExp(`Invalid import. "AlsoBanned" is not a known and stable API.`),
+                message: new RegExp(`Invalid import. "AlsoBanned" can't be imported from "lwc".`),
             },
         ],
     },
@@ -72,11 +72,11 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid import. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid import. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
             {
-                message: new RegExp(`Invalid import. "AlsoBanned" is not a known and stable API.`),
+                message: new RegExp(`Invalid import. "AlsoBanned" can't be imported from "lwc".`),
             },
         ],
     },
@@ -139,7 +139,7 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid export. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
         ],
@@ -149,7 +149,7 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid export. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
         ],
@@ -159,7 +159,7 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid export. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
         ],
@@ -169,7 +169,7 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid export. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
         ],
@@ -179,11 +179,11 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid export. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
             {
-                message: new RegExp(`Invalid export. "AlsoBanned" is not a known and stable API.`),
+                message: new RegExp(`Invalid export. "AlsoBanned" can't be imported from "lwc".`),
             },
         ],
     },
@@ -192,11 +192,11 @@ const invalidCases = [
         errors: [
             {
                 message: new RegExp(
-                    `Invalid export. "ShouldNotImport" is not a known and stable API.`,
+                    `Invalid export. "ShouldNotImport" can't be imported from "lwc".`,
                 ),
             },
             {
-                message: new RegExp(`Invalid export. "AlsoBanned" is not a known and stable API.`),
+                message: new RegExp(`Invalid export. "AlsoBanned" can't be imported from "lwc".`),
             },
         ],
     },
@@ -207,6 +207,89 @@ const invalidCases = [
                 message: new RegExp(
                     `Invalid export. Bare exports are not allowed on "lwc". Instead, use named exports: "export { LightningElement } from 'lwc'".`,
                 ),
+            },
+        ],
+    },
+
+    {
+        code: `import { LightningElement } from "lwc"`,
+        options: [
+            {
+                allowList: [],
+            },
+        ],
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid import. "LightningElement" can't be imported from "lwc".`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `export { LightningElement } from "lwc"`,
+        options: [
+            {
+                allowList: [],
+            },
+        ],
+        errors: [
+            {
+                message: new RegExp(
+                    `Invalid export. "LightningElement" can't be imported from "lwc".`,
+                ),
+            },
+        ],
+    },
+    {
+        code: `import { api } from "lwc"`,
+        options: [
+            {
+                allowList: ['LightningElement'],
+            },
+        ],
+        errors: [
+            {
+                message: new RegExp(`Invalid import. "api" can't be imported from "lwc".`),
+            },
+        ],
+    },
+    {
+        code: `import { Unknown as LightningElement } from "lwc"`,
+        options: [
+            {
+                allowList: ['LightningElement'],
+            },
+        ],
+        errors: [
+            {
+                message: new RegExp(`Invalid import. "Unknown" can't be imported from "lwc".`),
+            },
+        ],
+    },
+    {
+        code: `export { api } from "lwc"`,
+        options: [
+            {
+                allowList: ['LightningElement'],
+            },
+        ],
+        errors: [
+            {
+                message: new RegExp(`Invalid export. "api" can't be imported from "lwc".`),
+            },
+        ],
+    },
+    {
+        code: `export { Unknown as LightningElement } from "lwc"`,
+        options: [
+            {
+                allowList: ['LightningElement'],
+            },
+        ],
+        errors: [
+            {
+                message: new RegExp(`Invalid export. "Unknown" can't be imported from "lwc".`),
             },
         ],
     },
@@ -275,6 +358,47 @@ const validCases = [
     },
     {
         code: `export default 'foo'`,
+    },
+
+    {
+        code: `import { LightningElement } from "lwc"`,
+        options: [
+            {
+                allowList: ['LightningElement', 'api'],
+            },
+        ],
+    },
+    {
+        code: `import { LightningElement as LWCElement } from "lwc"`,
+        options: [
+            {
+                allowList: ['LightningElement', 'api'],
+            },
+        ],
+    },
+    {
+        code: `import { LightningElement, api } from "lwc"`,
+        options: [
+            {
+                allowList: ['LightningElement', 'api'],
+            },
+        ],
+    },
+    {
+        code: `export  { LightningElement } from "lwc"`,
+        options: [
+            {
+                allowList: ['LightningElement', 'api'],
+            },
+        ],
+    },
+    {
+        code: `export  { LightningElement, api } from "lwc"`,
+        options: [
+            {
+                allowList: ['LightningElement', 'api'],
+            },
+        ],
     },
 ];
 


### PR DESCRIPTION
This PR introduces the new `allowList` option to the `no-disallowed-lwc-imports` rule. When set this option overrides the default list of available APIs on `lwc`. 

**Misc:**
- Updated the error message to be more generic. 