### PR TITLE
feat: add options to disable export/bare import validation

### DIFF
--- a/docs/rules/no-disallowed-lwc-imports.md
+++ b/docs/rules/no-disallowed-lwc-imports.md
@@ -57,3 +57,31 @@ Examples of **correct** code:
 /* eslint lwc/valid-api: ["error", { "allowlist": ["LightningElement"] }] */
 import { LightningElement } from 'lwc';
 ```
+
+### `allowBareImports`
+
+The `allowBareImports` property, when set to `true`, allows the following to be treated as **correct** code:
+
+```js
+import 'lwc';
+```
+
+The default value is `false`.
+
+### `allowExports`
+
+The `allowExports` property, when set to `true`, allows any `exports` (such as the following) to be treated as **correct** code:
+
+```js
+export * from 'lwc';
+```
+
+```js
+export { LightningElement } from 'lwc';
+```
+
+```js
+export { doesNotExist } from 'lwc';
+```
+
+The default value is `false`.

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -123,7 +123,7 @@ module.exports = {
                     if (isLwcImport(node)) {
                         const { specifiers } = node;
                         if (!specifiers.length) {
-                            // export 'lwc'
+                            // export {} from "lwc"
                             context.report({
                                 message: `Invalid export. Bare exports are not allowed on "lwc". Instead, use named exports: "export { LightningElement } from 'lwc'".`,
                                 node,

--- a/lib/rules/no-disallowed-lwc-imports.js
+++ b/lib/rules/no-disallowed-lwc-imports.js
@@ -54,6 +54,14 @@ module.exports = {
                             type: 'string',
                         },
                     },
+                    allowBareImports: {
+                        type: 'boolean',
+                        default: false,
+                    },
+                    allowExports: {
+                        type: 'boolean',
+                        default: false,
+                    },
                 },
                 additionalProperties: false,
             },
@@ -64,8 +72,10 @@ module.exports = {
         // Use the API allow list provided by option to the ESLint rule, otherwise fallback to the
         // default one.
         let lwcAllowedApis = LWC_SUPPORTED_APIS;
-        if (context.options.length > 0 && context.options[0].allowlist) {
-            lwcAllowedApis = new Set(context.options[0].allowlist);
+        const options = context.options[0] || {};
+        const { allowlist, allowBareImports, allowExports } = options;
+        if (allowlist) {
+            lwcAllowedApis = new Set(allowlist);
         }
 
         return {
@@ -74,10 +84,12 @@ module.exports = {
                     const { specifiers } = node;
                     if (!specifiers.length) {
                         // import 'lwc'
-                        context.report({
-                            message: `Invalid import. Bare imports are not allowed on "lwc". Instead, use named imports: "import { LightningElement } from 'lwc'".`,
-                            node,
-                        });
+                        if (!allowBareImports) {
+                            context.report({
+                                message: `Invalid import. Bare imports are not allowed on "lwc". Instead, use named imports: "import { LightningElement } from 'lwc'".`,
+                                node,
+                            });
+                        }
                     }
                     for (const specifier of specifiers) {
                         const { type, imported } = specifier;
@@ -107,34 +119,38 @@ module.exports = {
                 }
             },
             ExportNamedDeclaration(node) {
-                if (isLwcImport(node)) {
-                    const { specifiers } = node;
-                    if (!specifiers.length) {
-                        // export 'lwc'
-                        context.report({
-                            message: `Invalid export. Bare exports are not allowed on "lwc". Instead, use named exports: "export { LightningElement } from 'lwc'".`,
-                            node,
-                        });
-                    }
-                    for (const specifier of specifiers) {
-                        const { type, local } = specifier;
-                        if (type === 'ExportSpecifier' && !lwcAllowedApis.has(local.name)) {
-                            // export { fake } from 'lwc'
+                if (!allowExports) {
+                    if (isLwcImport(node)) {
+                        const { specifiers } = node;
+                        if (!specifiers.length) {
+                            // export 'lwc'
                             context.report({
-                                message: `Invalid export. "${local.name}" can't be imported from "lwc".`,
-                                node: specifier,
+                                message: `Invalid export. Bare exports are not allowed on "lwc". Instead, use named exports: "export { LightningElement } from 'lwc'".`,
+                                node,
                             });
+                        }
+                        for (const specifier of specifiers) {
+                            const { type, local } = specifier;
+                            if (type === 'ExportSpecifier' && !lwcAllowedApis.has(local.name)) {
+                                // export { fake } from 'lwc'
+                                context.report({
+                                    message: `Invalid export. "${local.name}" can't be imported from "lwc".`,
+                                    node: specifier,
+                                });
+                            }
                         }
                     }
                 }
             },
             ExportAllDeclaration(node) {
-                if (isLwcImport(node)) {
-                    // export * from 'lwc'
-                    context.report({
-                        message: `Invalid export. Exporting from "lwc" is not allowed.`,
-                        node,
-                    });
+                if (!allowExports) {
+                    if (isLwcImport(node)) {
+                        // export * from 'lwc'
+                        context.report({
+                            message: `Invalid export. Exporting from "lwc" is not allowed.`,
+                            node,
+                        });
+                    }
                 }
             },
         };

--- a/test/lib/rules/no-disallowed-lwc-imports.js
+++ b/test/lib/rules/no-disallowed-lwc-imports.js
@@ -400,6 +400,54 @@ const validCases = [
             },
         ],
     },
+    {
+        code: `import 'lwc'`,
+        options: [
+            {
+                allowBareImports: true,
+            },
+        ],
+    },
+    {
+        code: `export  { LightningElement } from "lwc"`,
+        options: [
+            {
+                allowExports: true,
+            },
+        ],
+    },
+    {
+        code: `export  { doesNotExist } from "lwc"`,
+        options: [
+            {
+                allowExports: true,
+            },
+        ],
+    },
+    {
+        code: `export {} from 'lwc'`,
+        options: [
+            {
+                allowExports: true,
+            },
+        ],
+    },
+    {
+        code: `export * as foo from 'lwc'`,
+        options: [
+            {
+                allowExports: true,
+            },
+        ],
+    },
+    {
+        code: `export * from 'lwc'`,
+        options: [
+            {
+                allowExports: true,
+            },
+        ],
+    },
 ];
 
 ruleTester.run('no-disallowed-lwc-imports', rule, {


### PR DESCRIPTION
Adds two new options to allow bare imports and exports for backwards compatibility purposes.

See: W-11690641