### PR TITLE
Add `lwc/consistent-component-name` support for `.ts` files

### DIFF
--- a/lib/rules/consistent-component-name.js
+++ b/lib/rules/consistent-component-name.js
@@ -28,7 +28,7 @@ module.exports = {
         const fileName = context.getFilename();
         const sourceCode = context.getSourceCode();
 
-        const fileBasename = path.basename(fileName, '.js');
+        const fileBasename = path.basename(fileName, path.extname(fileName));
         const expectComponentName = fileBasename.charAt(0).toUpperCase() + fileBasename.slice(1);
 
         return {

--- a/test/lib/rules/consistent-component-name.js
+++ b/test/lib/rules/consistent-component-name.js
@@ -26,6 +26,17 @@ ruleTester.run('consistent-class-name', rule, {
             code: `export class ComplexName extends LightningElement {}`,
             filename: 'complexName.js',
         },
+        {
+            code: `
+                import { LightningElement } from 'lwc';
+                export class Foo extends LightningElement {}
+            `,
+            filename: 'foo.ts',
+        },
+        {
+            code: `export class ComplexName extends LightningElement {}`,
+            filename: 'complexName.ts',
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION
The `lwc/consistent-component-name` rule fails for `.ts` files as described in #109 . This PR aims to solve it by agnostically removing the extension from the file being checked, thus including `.js` and `.ts` files. This also opens up to other file extensions, but from what I gather, that shouldn't cause problems.