### PR TITLE
feat: update rule `no-browser-globals-during-ssr` to be more open

### DIFF
--- a/lib/rule-helpers.js
+++ b/lib/rule-helpers.js
@@ -14,7 +14,6 @@ const { isGlobalIdentifier } = require('./util/scope');
  */
 function reachableDuringSSRPartial() {
     let moduleInfo;
-    let insideLWC = false;
     let reachableFunctionThatWeAreIn = null;
     let reachableMethodThatWeAreIn = null;
     let skippedBlockThatWeAreIn = null;
@@ -24,22 +23,16 @@ function reachableDuringSSRPartial() {
         Program: (node) => {
             moduleInfo = analyze(node);
         },
-        ClassDeclaration: (node) => {
-            if (node === moduleInfo.lwcClassDeclaration) {
-                insideLWC = true;
-            }
-        },
-        'ClassDeclaration:exit': (node) => {
-            if (node === moduleInfo.lwcClassDeclaration) {
-                insideLWC = false;
-            }
-        },
         FunctionDeclaration: (node) => {
             if (
                 !reachableFunctionThatWeAreIn &&
                 node.id &&
                 node.id.type === 'Identifier' &&
-                moduleInfo.moduleScopedFunctionsReachableDuringSSR.has(node.id && node.id.name)
+                ((moduleInfo.isLWC &&
+                    moduleInfo.moduleScopedFunctionsReachableDuringSSR.has(
+                        node.id && node.id.name,
+                    )) ||
+                    !moduleInfo.isLWC)
             ) {
                 reachableFunctionThatWeAreIn = node;
             }
@@ -54,7 +47,9 @@ function reachableDuringSSRPartial() {
                 !reachableFunctionThatWeAreIn &&
                 node.parent.type === 'VariableDeclarator' &&
                 node.parent.id.type === 'Identifier' &&
-                moduleInfo.moduleScopedFunctionsReachableDuringSSR.has(node.parent.id.name)
+                ((moduleInfo.isLWC &&
+                    moduleInfo.moduleScopedFunctionsReachableDuringSSR.has(node.parent.id.name)) ||
+                    !moduleInfo.isLWC)
             ) {
                 reachableFunctionThatWeAreIn = node;
             }
@@ -69,7 +64,9 @@ function reachableDuringSSRPartial() {
                 !reachableFunctionThatWeAreIn &&
                 node.parent.type === 'VariableDeclarator' &&
                 node.parent.id.type === 'Identifier' &&
-                moduleInfo.moduleScopedFunctionsReachableDuringSSR.has(node.parent.id.name)
+                ((moduleInfo.isLWC &&
+                    moduleInfo.moduleScopedFunctionsReachableDuringSSR.has(node.parent.id.name)) ||
+                    !moduleInfo.isLWC)
             ) {
                 reachableFunctionThatWeAreIn = node;
             }
@@ -81,9 +78,9 @@ function reachableDuringSSRPartial() {
         },
         MethodDefinition: (node) => {
             if (
-                insideLWC &&
                 node.key.type === 'Identifier' &&
-                moduleInfo.methodsReachableDuringSSR.has(node.key.name)
+                ((moduleInfo.isLWC && moduleInfo.methodsReachableDuringSSR.has(node.key.name)) ||
+                    !moduleInfo.isLWC)
             ) {
                 reachableMethodThatWeAreIn = node;
             }
@@ -115,7 +112,7 @@ function reachableDuringSSRPartial() {
 
     return {
         withinLWCVisitors,
-        isInsideReachableMethod: () => insideLWC && !!reachableMethodThatWeAreIn,
+        isInsideReachableMethod: () => !!reachableMethodThatWeAreIn,
         isInsideReachableFunction: () => !!reachableFunctionThatWeAreIn,
         isInsideSkippedBlock: () => !!skippedBlockThatWeAreIn || !!skippedConditionThatWeAreIn,
     };
@@ -194,22 +191,6 @@ module.exports.noReferenceDuringSSR = function noReferenceDuringSSR(
                     },
                 });
             } else if (
-                node.parent.type !== 'MemberExpression' &&
-                node.object.type === 'Identifier' &&
-                forbiddenGlobalNames.has(node.object.name) &&
-                isGlobalIdentifier(node.object, context.getScope())
-            ) {
-                // Prevents expressions like:
-                // document.addEventListener('click', () => { ... });
-                // document?.addEventListener('click', () => { ... });
-                context.report({
-                    messageId: messageIds.at(0),
-                    node,
-                    data: {
-                        identifier: node.object.name,
-                    },
-                });
-            } else if (
                 node.parent.type === 'CallExpression' &&
                 node.parent.optional !== true &&
                 node.object.type === 'Identifier' &&
@@ -233,6 +214,25 @@ module.exports.noReferenceDuringSSR = function noReferenceDuringSSR(
                                 : node.object.name,
                     },
                 });
+            } else if (
+                node.parent.type !== 'MemberExpression' &&
+                node.object.type === 'Identifier' &&
+                forbiddenGlobalNames.has(node.object.name) &&
+                isGlobalIdentifier(node.object, context.getScope())
+            ) {
+                // Prevents expressions like:
+                // window.addEventListener('click', () => { ... });
+                // window?.addEventListener('click', () => { ... });
+                // document.addEventListener('click', () => { ... });
+                // document?.addEventListener('click', () => { ... });
+                context.report({
+                    messageId: messageIds.at(0),
+                    node,
+                    data: {
+                        identifier:
+                            node.object.name === 'window' ? node.property.name : node.object.name,
+                    },
+                });
             }
         },
         Identifier: (node) => {
@@ -244,6 +244,7 @@ module.exports.noReferenceDuringSSR = function noReferenceDuringSSR(
             ) {
                 return;
             }
+
             if (
                 noReferenceParentQualifiers.has(node.parent.type) &&
                 forbiddenGlobalNames.has(node.name) &&
@@ -255,6 +256,43 @@ module.exports.noReferenceDuringSSR = function noReferenceDuringSSR(
 
                 // Allows expressions like:
                 // doSomethingWith(globalThis)
+                context.report({
+                    messageId: messageIds.at(0),
+                    node,
+                    data: {
+                        identifier: node.name,
+                    },
+                });
+            } else if (
+                node.parent.type === 'BinaryExpression' &&
+                node.parent.operator === 'instanceof' &&
+                node.parent.right === node &&
+                forbiddenGlobalNames.has(node.name) &&
+                isGlobalIdentifier(node, context.getScope())
+            ) {
+                // Prevents expressions like:
+                // if (value instanceof Element) { ... }
+                // value instanceof Element ? doX() : doY();
+                context.report({
+                    messageId: messageIds.at(0),
+                    node,
+                    data: {
+                        identifier: node.name,
+                    },
+                });
+            }
+        },
+        ExpressionStatement: (node) => {
+            if (
+                node.parent.type === 'Program' &&
+                node.expression.type === 'CallExpression' &&
+                node.expression.callee.type === 'Identifier' &&
+                forbiddenGlobalNames.has(node.expression.callee.name) &&
+                isGlobalIdentifier(node, context.getScope())
+            ) {
+                // Prevents global expressions like:
+                // addEventListener('resize', () => {...});
+
                 context.report({
                     messageId: messageIds.at(0),
                     node,

--- a/test/lib/rules/no-restricted-browser-globals-during-ssr.js
+++ b/test/lib/rules/no-restricted-browser-globals-during-ssr.js
@@ -454,7 +454,7 @@ tester.run('no-browser-globals-during-ssr', rule, {
             errors: [
                 {
                     messageId: 'prohibitedBrowserAPIUsage',
-                    data: { identifier: 'window' },
+                    data: { identifier: 'foo' },
                 },
             ],
         },
@@ -475,7 +475,7 @@ tester.run('no-browser-globals-during-ssr', rule, {
             errors: [
                 {
                     messageId: 'prohibitedBrowserAPIUsage',
-                    data: { identifier: 'window' },
+                    data: { identifier: 'bar' },
                 },
             ],
         },
@@ -534,7 +534,7 @@ tester.run('no-browser-globals-during-ssr', rule, {
             errors: [
                 {
                     messageId: 'prohibitedBrowserAPIUsage',
-                    data: { identifier: 'window' },
+                    data: { identifier: 'x' },
                 },
             ],
         },
@@ -553,7 +553,7 @@ tester.run('no-browser-globals-during-ssr', rule, {
             errors: [
                 {
                     messageId: 'prohibitedBrowserAPIUsage',
-                    data: { identifier: 'window' },
+                    data: { identifier: 'x' },
                 },
             ],
         },
@@ -572,7 +572,7 @@ tester.run('no-browser-globals-during-ssr', rule, {
             errors: [
                 {
                     messageId: 'prohibitedBrowserAPIUsage',
-                    data: { identifier: 'window' },
+                    data: { identifier: 'x' },
                 },
             ],
         },
@@ -590,7 +590,7 @@ tester.run('no-browser-globals-during-ssr', rule, {
             errors: [
                 {
                     messageId: 'prohibitedBrowserAPIUsage',
-                    data: { identifier: 'window' },
+                    data: { identifier: 'x' },
                 },
             ],
         },
@@ -605,7 +605,7 @@ tester.run('no-browser-globals-during-ssr', rule, {
             errors: [
                 {
                     messageId: 'prohibitedBrowserAPIUsage',
-                    data: { identifier: 'window' },
+                    data: { identifier: 'x' },
                 },
             ],
         },
@@ -821,6 +821,93 @@ tester.run('no-browser-globals-during-ssr', rule, {
                 {
                     messageId: 'prohibitedBrowserAPIUsageGlobal',
                     data: { identifier: 'location', property: 'href' },
+                },
+            ],
+        },
+        {
+            code: `
+                function utility() {
+                  window.fuzzAround();
+                }
+
+                export default class Foo {
+                  bar() {
+                    utility();
+                  }
+                }
+            `,
+            errors: [
+                {
+                    messageId: 'prohibitedBrowserAPIUsage',
+                    data: { identifier: 'fuzzAround' },
+                },
+            ],
+        },
+        {
+            code: `addEventListener('resize', () => {});`,
+            errors: [
+                {
+                    messageId: 'prohibitedBrowserAPIUsage',
+                    data: { identifier: 'addEventListener' },
+                },
+            ],
+        },
+        {
+            code: `
+                function utility() {
+                    console.log(window.x);
+                }
+            `,
+            errors: [
+                {
+                    messageId: 'prohibitedBrowserAPIUsage',
+                    data: { identifier: 'x' },
+                },
+            ],
+        },
+        {
+            code: `
+                function getAttributes(element) {
+                    if (element instanceof Element) {
+                        return element.getAttributeNames();
+                    }
+                    return [];
+                }
+            `,
+            errors: [
+                {
+                    messageId: 'prohibitedBrowserAPIUsage',
+                    data: { identifier: 'Element' },
+                },
+            ],
+        },
+        {
+            code: `
+                function getAttributes(element) {
+                    return element instanceof Element ? element.getAttributeNames() : [];
+                }
+            `,
+            errors: [
+                {
+                    messageId: 'prohibitedBrowserAPIUsage',
+                    data: { identifier: 'Element' },
+                },
+            ],
+        },
+        {
+            code: `
+                function getJson(response) {
+                    if (response instanceof Response) {
+                        return response.json();
+                    }
+                    return Promise.resolve();
+                }
+            `,
+            options: [{ 'restricted-globals': { Response: true } }],
+            errors: [
+                {
+                    messageId: 'prohibitedBrowserAPIUsage',
+                    data: { identifier: 'Response' },
                 },
             ],
         },


### PR DESCRIPTION
The `no-browser-globals-during-ssr` is very limited in its current detection capabilities as it doesn't detect the use of non-SSRable browser APIs outside the context of LWCs. If bundles e.g. reference browser-only APIs in utility methods, these references pass without warnings. This PR keeps the old behavior for LWCs, but warns/errors about the use of non-SSRable Web APIs more aggressively outside LWCs.