### PR TITLE
fix: use node v18 while deploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/node
+      - image: cimg/node:18.18.0
     steps:
       - checkout
       - restore_yarn_cache


### PR DESCRIPTION
Use node v18 while deploying in Circle CI.