### PR TITLE
feat: eslint9 compatibility

### DIFF
--- a/lib/rule-helpers.js
+++ b/lib/rule-helpers.js
@@ -8,6 +8,7 @@
 const { analyze } = require('./analyze-component');
 const { isSSREscape } = require('./util/ssr');
 const { isGlobalIdentifier } = require('./util/scope');
+const { getScope, getAncestors } = require('./util/context');
 
 /**
  * Visitors for detecting methods/functions that are reachable during SSR
@@ -133,7 +134,7 @@ const noReferenceParentQualifiers = new Set([
 const globalAccessQualifiers = new Set(['CallExpression', 'MemberExpression']);
 
 function inModuleScope(node, context) {
-    for (const ancestor of context.getAncestors()) {
+    for (const ancestor of getAncestors(context, node)) {
         if (moduleScopeDisqualifiers.has(ancestor.type)) {
             return false;
         }
@@ -172,7 +173,7 @@ module.exports.noReferenceDuringSSR = function noReferenceDuringSSR(
                     node.object.name === 'window') &&
                 node.property.type === 'Identifier' &&
                 forbiddenGlobalNames.has(node.property.name) &&
-                isGlobalIdentifier(node.object, context.getScope())
+                isGlobalIdentifier(node.object, getScope(context, node))
             ) {
                 // Prevents expressions like:
                 // globalThis.document.addEventListener('click', () => { ... });
@@ -197,7 +198,7 @@ module.exports.noReferenceDuringSSR = function noReferenceDuringSSR(
                 node.object.name === 'globalThis' &&
                 node.property.type === 'Identifier' &&
                 forbiddenGlobalNames.has(node.property.name) &&
-                isGlobalIdentifier(node.object, context.getScope())
+                isGlobalIdentifier(node.object, getScope(context, node))
             ) {
                 // Prevents expressions like:
                 // globalThis.addEventListener('click', () => { ... });
@@ -218,7 +219,7 @@ module.exports.noReferenceDuringSSR = function noReferenceDuringSSR(
                 node.parent.type !== 'MemberExpression' &&
                 node.object.type === 'Identifier' &&
                 forbiddenGlobalNames.has(node.object.name) &&
-                isGlobalIdentifier(node.object, context.getScope())
+                isGlobalIdentifier(node.object, getScope(context, node))
             ) {
                 // Prevents expressions like:
                 // window.addEventListener('click', () => { ... });
@@ -248,7 +249,7 @@ module.exports.noReferenceDuringSSR = function noReferenceDuringSSR(
             if (
                 noReferenceParentQualifiers.has(node.parent.type) &&
                 forbiddenGlobalNames.has(node.name) &&
-                isGlobalIdentifier(node, context.getScope())
+                isGlobalIdentifier(node, getScope(context, node))
             ) {
                 // Prevents expressions like:
                 // doSomethingWith(window);
@@ -268,7 +269,7 @@ module.exports.noReferenceDuringSSR = function noReferenceDuringSSR(
                 node.parent.operator === 'instanceof' &&
                 node.parent.right === node &&
                 forbiddenGlobalNames.has(node.name) &&
-                isGlobalIdentifier(node, context.getScope())
+                isGlobalIdentifier(node, getScope(context, node))
             ) {
                 // Prevents expressions like:
                 // if (value instanceof Element) { ... }
@@ -288,7 +289,7 @@ module.exports.noReferenceDuringSSR = function noReferenceDuringSSR(
                 node.expression.type === 'CallExpression' &&
                 node.expression.callee.type === 'Identifier' &&
                 forbiddenGlobalNames.has(node.expression.callee.name) &&
-                isGlobalIdentifier(node, context.getScope())
+                isGlobalIdentifier(node, getScope(context, node))
             ) {
                 // Prevents global expressions like:
                 // addEventListener('resize', () => {...});

--- a/lib/rules/consistent-component-name.js
+++ b/lib/rules/consistent-component-name.js
@@ -10,6 +10,7 @@ const path = require('path');
 
 const { docUrl } = require('../util/doc-url');
 const { isComponent } = require('../util/component');
+const { getSourceCode } = require('../util/context');
 
 module.exports = {
     meta: {
@@ -26,7 +27,7 @@ module.exports = {
     },
     create(context) {
         const fileName = context.getFilename();
-        const sourceCode = context.getSourceCode();
+        const sourceCode = getSourceCode(context);
 
         const fileBasename = path.basename(fileName, path.extname(fileName));
         const expectComponentName = fileBasename.charAt(0).toUpperCase() + fileBasename.slice(1);

--- a/lib/rules/no-async-operation.js
+++ b/lib/rules/no-async-operation.js
@@ -8,6 +8,7 @@
 
 const { docUrl } = require('../util/doc-url');
 const { isGlobalIdentifier } = require('../util/scope');
+const { getScope } = require('../util/context');
 
 const GLOBAL_OBJECT = 'window';
 
@@ -29,7 +30,7 @@ module.exports = {
         return {
             CallExpression(node) {
                 const { callee } = node;
-                const scope = context.getScope();
+                const scope = getScope(context, node);
 
                 // Check for direct invocation of global restricted APIs.
                 // eg. setTimeout() or requestAnimationFrame();

--- a/lib/rules/no-leaky-event-listeners.js
+++ b/lib/rules/no-leaky-event-listeners.js
@@ -8,6 +8,7 @@
 
 const { docUrl } = require('../util/doc-url');
 const { isGlobalIdentifier } = require('../util/scope');
+const { getScope } = require('../util/context');
 
 module.exports = {
     meta: {
@@ -83,7 +84,7 @@ module.exports = {
         return {
             CallExpression(node) {
                 const { callee } = node;
-                const scope = context.getScope();
+                const scope = getScope(context, node);
 
                 // Handle cases where the method is attached on the global object:
                 // - addEventListener('click', () => {});

--- a/lib/rules/no-unexpected-wire-adapter-usages.js
+++ b/lib/rules/no-unexpected-wire-adapter-usages.js
@@ -9,6 +9,7 @@
 const { Minimatch } = require('minimatch');
 const { docUrl } = require('../util/doc-url');
 const { isWireDecorator } = require('../util/decorator');
+const { getScope } = require('../util/context');
 
 function getImportedIdentifier(specifierNode) {
     // Namespace imports are not analyzed because it is impossible to track accurately the usage of
@@ -66,7 +67,7 @@ module.exports = {
 
         return {
             ImportDeclaration(node) {
-                const scope = context.getScope();
+                const scope = getScope(context, node);
                 const moduleIdentifier = node.source.value;
 
                 for (const specifier of node.specifiers) {

--- a/lib/rules/no-unknown-wire-adapters.js
+++ b/lib/rules/no-unknown-wire-adapters.js
@@ -9,6 +9,7 @@
 const { Minimatch } = require('minimatch');
 
 const { docUrl } = require('../util/doc-url');
+const { getScope } = require('../util/context');
 
 module.exports = {
     meta: {
@@ -76,7 +77,7 @@ module.exports = {
                 const adapterName = adapterNode.name;
 
                 // Let's resolve the reference to the wire adapter identifier in the current scope.
-                const scope = context.getScope();
+                const scope = getScope(context, node);
                 const adapterVariable = scope.references.find(
                     (r) => r.identifier === adapterNode,
                 ).resolved;

--- a/lib/rules/prefer-custom-event.js
+++ b/lib/rules/prefer-custom-event.js
@@ -8,6 +8,7 @@
 
 const { docUrl } = require('../util/doc-url');
 const { isGlobalIdentifier } = require('../util/scope');
+const { getScope } = require('../util/context');
 
 module.exports = {
     meta: {
@@ -25,7 +26,7 @@ module.exports = {
         return {
             NewExpression(node) {
                 const { callee } = node;
-                const scope = context.getScope();
+                const scope = getScope(context, node);
 
                 if (
                     callee.type === 'Identifier' &&

--- a/lib/util/component.js
+++ b/lib/util/component.js
@@ -6,6 +6,8 @@
  */
 'use strict';
 
+const { getAncestors } = require('./context');
+
 /**
  * Returns true if the node is a LWC component.
  *
@@ -19,7 +21,7 @@ function isComponent(node, context) {
         return false;
     }
 
-    const program = context.getAncestors(node).find(({ type }) => type === 'Program');
+    const program = getAncestors(context, node).find(({ type }) => type === 'Program');
 
     const importDeclaration = program.body
         .filter(({ type }) => type === 'ImportDeclaration')

--- a/lib/util/context.js
+++ b/lib/util/context.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+function getSourceCode(context) {
+    if ('sourceCode' in context) {
+        return context.sourceCode;
+    }
+
+    return context.getSourceCode();
+}
+
+function getScope(context, node) {
+    const sourceCode = getSourceCode(context);
+
+    if (sourceCode && sourceCode.getScope) {
+        return sourceCode.getScope(node);
+    }
+
+    return context.getScope();
+}
+
+function getAncestors(context, node) {
+    const sourceCode = getSourceCode(context);
+
+    if (sourceCode && sourceCode.getAncestors) {
+        return sourceCode.getAncestors(node);
+    }
+
+    return context.getAncestors();
+}
+
+module.exports = {
+    getSourceCode,
+    getScope,
+    getAncestors,
+};

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@babel/eslint-parser": "^7",
-    "eslint": "^7 || ^8"
+    "eslint": "^7 || ^8 || ^9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## description
This adds support for ESLint v9 by replacing deprecated function calls.
The `context.js` is just needed for compatibility with v7.
If this was my project, i would just drop v7 support and remove it, but that is your call ;)