### PR TITLE
Update @lwc/lwc/valid-api eslint for data

### DIFF
--- a/docs/rules/valid-api.md
+++ b/docs/rules/valid-api.md
@@ -5,7 +5,8 @@ The following restrictions apply to the `@api` decorator:
 -   Apply to class fields and class methods only.
 -   Fields and methods should be unique per class.
 -   Fields and methods can't start with `on`. The `on` prefix is reserved to bind event handlers.
--   Fields and methods can't start with `data`, `slot` or `part`. These names are reserved by LWC.
+-   Fields and methods can't be named `slot`, `part` or `dataset`. These names are reserved by LWC.
+-   Fields and methods can't start with `data[A-Z]`. These are mapped to the reflected property `this.dataset.*`.
 -   Boolean properties must be initialized with `false`. By initializing a public property to `true`, the consumer component can't set its value to `false` via the template.
 
 ## Rule details

--- a/lib/rules/valid-api.js
+++ b/lib/rules/valid-api.js
@@ -13,7 +13,7 @@ const { isClassField } = require('../util/isClassField');
 /**
  * Set of APIs that we reserved for forward compatibility of LWC.
  */
-const RESERVED_PUBLIC_PROPERTIES = new Set(['slot', 'part']);
+const RESERVED_PUBLIC_PROPERTIES = new Set(['slot', 'part', 'dataset']);
 
 /**
  * Maps containing attributes that have a camelCased property mapping. We do not want users
@@ -68,7 +68,7 @@ function validatePropertyName(property, context) {
         });
     }
 
-    if (name.startsWith('data')) {
+    if (name.match(/data.+/)) {
         context.report({
             node: property,
             message: `Invalid public property "${name}". Properties starting with "data" are reserved properties.`,

--- a/lib/rules/valid-api.js
+++ b/lib/rules/valid-api.js
@@ -68,17 +68,17 @@ function validatePropertyName(property, context) {
         });
     }
 
-    if (name.startsWith('data') && name !== 'data') {
-        context.report({
-            node: property,
-            message: `Invalid public property "${name}". Properties starting with "data" are reserved properties.`,
-        });
-    }
-
     if (RESERVED_PUBLIC_PROPERTIES.has(name)) {
         context.report({
             node: property,
             message: `Invalid public property "${name}". This property name is a reserved property.`,
+        });
+    }
+
+    if (name.startsWith('data') && name !== 'data') {
+        context.report({
+            node: property,
+            message: `Invalid public property "${name}". Properties starting with "data" are reserved properties.`,
         });
     }
 

--- a/lib/rules/valid-api.js
+++ b/lib/rules/valid-api.js
@@ -73,7 +73,7 @@ function validatePropertyName(property, context) {
             node: property,
             message: `Invalid public property "${name}". This property name is a reserved property.`,
         });
-    } else if (name.startsWith('data') && name !== 'data') {
+    } else if (/^data[A-Z]/.test(name)) {
         context.report({
             node: property,
             message: `Invalid public property "${name}". Properties starting with "data" are reserved properties.`,

--- a/lib/rules/valid-api.js
+++ b/lib/rules/valid-api.js
@@ -68,7 +68,7 @@ function validatePropertyName(property, context) {
         });
     }
 
-    if (name.match(/data.+/)) {
+    if (name.startsWith('data') && name !== 'data') {
         context.report({
             node: property,
             message: `Invalid public property "${name}". Properties starting with "data" are reserved properties.`,

--- a/lib/rules/valid-api.js
+++ b/lib/rules/valid-api.js
@@ -73,9 +73,7 @@ function validatePropertyName(property, context) {
             node: property,
             message: `Invalid public property "${name}". This property name is a reserved property.`,
         });
-    }
-
-    if (name.startsWith('data') && !['dataset', 'data'].includes(name)) {
+    } else if (name.startsWith('data') && name !== 'data') {
         context.report({
             node: property,
             message: `Invalid public property "${name}". Properties starting with "data" are reserved properties.`,

--- a/lib/rules/valid-api.js
+++ b/lib/rules/valid-api.js
@@ -75,7 +75,7 @@ function validatePropertyName(property, context) {
         });
     }
 
-    if (name.startsWith('data') && !(['dataset', 'data'].includes(name))) {
+    if (name.startsWith('data') && !['dataset', 'data'].includes(name)) {
         context.report({
             node: property,
             message: `Invalid public property "${name}". Properties starting with "data" are reserved properties.`,

--- a/lib/rules/valid-api.js
+++ b/lib/rules/valid-api.js
@@ -76,7 +76,7 @@ function validatePropertyName(property, context) {
     } else if (/^data[A-Z]/.test(name)) {
         context.report({
             node: property,
-            message: `Invalid public property "${name}". Properties starting with "data" are reserved properties.`,
+            message: `Invalid public property name "${name}". Properties starting with "data" correspond to data-* HTML attributes, which are not allowed.`,
         });
     }
 

--- a/lib/rules/valid-api.js
+++ b/lib/rules/valid-api.js
@@ -75,7 +75,7 @@ function validatePropertyName(property, context) {
         });
     }
 
-    if (name.startsWith('data') && name !== 'data') {
+    if (name.startsWith('data') && !(['dataset', 'data'].includes(name))) {
         context.report({
             node: property,
             message: `Invalid public property "${name}". Properties starting with "data" are reserved properties.`,

--- a/test/lib/rules/valid-api.js
+++ b/test/lib/rules/valid-api.js
@@ -139,7 +139,7 @@ testRule('valid-api', {
             errors: [
                 {
                     message:
-                        'Invalid public property "dataFooBar". Properties starting with "data" are reserved properties.',
+                        'Invalid public property "dataFooBar". Properties starting with "data" correspond to data-* HTML attributes, which are not allowed.',
                 },
             ],
         },
@@ -439,7 +439,7 @@ testTypeScript('valid-api', {
             errors: [
                 {
                     message:
-                        'Invalid public property "dataFooBar". Properties starting with "data" are reserved properties.',
+                        'Invalid public property "dataFooBar". Properties starting with "data" correspond to data-* HTML attributes, which are not allowed.',
                 },
             ],
         },

--- a/test/lib/rules/valid-api.js
+++ b/test/lib/rules/valid-api.js
@@ -16,6 +16,12 @@ testRule('valid-api', {
         {
             code: `import { api } from 'lwc';
         class Foo {
+            @api data
+        }`,
+        },
+        {
+            code: `import { api } from 'lwc';
+        class Foo {
             @api foo
         }`,
         },
@@ -128,18 +134,6 @@ testRule('valid-api', {
         {
             code: `import { api } from 'lwc';
             class Foo {
-                @api data;
-            }`,
-            errors: [
-                {
-                    message:
-                        'Invalid public property "data". Properties starting with "data" are reserved properties.',
-                },
-            ],
-        },
-        {
-            code: `import { api } from 'lwc';
-            class Foo {
                 @api dataFooBar;
             }`,
             errors: [
@@ -192,6 +186,18 @@ testRule('valid-api', {
                 {
                     message:
                         'Invalid public property "part". This property name is a reserved property.',
+                },
+            ],
+        },
+        {
+            code: `import { api } from 'lwc';
+            class Foo {
+                @api dataset;
+            }`,
+            errors: [
+                {
+                    message:
+                        'Invalid public property "dataset". This property name is a reserved property.',
                 },
             ],
         },
@@ -295,6 +301,12 @@ testRule('valid-api', {
 
 testTypeScript('valid-api', {
     valid: [
+        {
+            code: `import { api } from 'lwc';
+        class Foo {
+            @api data: string
+        }`,
+        },
         {
             code: `import { api } from 'lwc';
         class Foo {
@@ -410,12 +422,12 @@ testTypeScript('valid-api', {
         {
             code: `import { api } from 'lwc';
             class Foo {
-                @api data: string;
+                @api dataset: string;
             }`,
             errors: [
                 {
                     message:
-                        'Invalid public property "data". Properties starting with "data" are reserved properties.',
+                        'Invalid public property "dataset". This property name is a reserved property.',
                 },
             ],
         },

--- a/test/lib/rules/valid-api.js
+++ b/test/lib/rules/valid-api.js
@@ -139,7 +139,7 @@ testRule('valid-api', {
             errors: [
                 {
                     message:
-                        'Invalid public property "dataFooBar". Properties starting with "data" correspond to data-* HTML attributes, which are not allowed.',
+                        'Invalid public property name "dataFooBar". Properties starting with "data" correspond to data-* HTML attributes, which are not allowed.',
                 },
             ],
         },
@@ -439,7 +439,7 @@ testTypeScript('valid-api', {
             errors: [
                 {
                     message:
-                        'Invalid public property "dataFooBar". Properties starting with "data" correspond to data-* HTML attributes, which are not allowed.',
+                        'Invalid public property name "dataFooBar". Properties starting with "data" correspond to data-* HTML attributes, which are not allowed.',
                 },
             ],
         },


### PR DESCRIPTION
This PR updates the restriction on `data` to not include `data` itself since this is a valid api name. It also adds `dataset` to the list of reserved apis.