### PR TITLE
@W-17070470 Only check functions called on first paint

### DIFF
--- a/test/lib/rules/no-restricted-browser-globals-during-ssr.js
+++ b/test/lib/rules/no-restricted-browser-globals-during-ssr.js
@@ -319,6 +319,17 @@ testRule('no-restricted-browser-globals-during-ssr', {
                 }
             `,
         },
+        {
+            code: `
+              import { LightningElement } from 'lwc';
+
+              export default class Foo extends LightningElement {
+                handleFocus() {
+                  console.log(window.location.href);
+                }
+              }
+            `,
+        },
     ],
     invalid: [
         {

--- a/test/lib/rules/no-unsupported-ssr-properties.js
+++ b/test/lib/rules/no-unsupported-ssr-properties.js
@@ -196,6 +196,17 @@ testRule('no-unsupported-ssr-properties', {
               }
             `,
         },
+        {
+            code: `
+              import { LightningElement } from 'lwc';
+
+              export default class Foo extends LightningElement {
+                handleFocus() {
+                  this.dispatchEvent(new CustomEvent('focus'));
+                }
+              }
+            `,
+        },
     ],
     invalid: [
         {


### PR DESCRIPTION
Looks like this issue was not a problem, but I wanted to add our tests cases that had been throwing this error to confirm. All looks good :) 

Link to GitHub Issue: https://github.com/salesforce/eslint-plugin-lwc/issues/159