### PR TITLE
fix: add meta tags for plugin exports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-supported-eslint-versions: &supported-eslint-versions ["local", "9"]
+supported-eslint-versions: &supported-eslint-versions ["local"]
 
 deploy_filters: &deploy_filters
   filters:

--- a/README.md
+++ b/README.md
@@ -10,53 +10,74 @@ $ npm install eslint @babel/core @babel/eslint-parser @lwc/eslint-plugin-lwc --s
 
 ## Usage
 
-Add `@lwc/eslint-plugin-lwc` to the `plugins` section of your configuration. Then configure the desired rules in the `rules` sections. Some of the syntax used in Lightning Web Components is not yet stage 4 (eg. class fields or decorators), and the out-of-the-box parser from ESLint doesn't support this syntax yet. In order to parse the LWC files properly, set the `parser` field to [`@babel/eslint-parser`](https://github.com/babel/babel/tree/main/eslint/babel-eslint-parser).
+_Starting with v2.0.0, @lwc/eslint-plugin-lwc only supports eslint@v9. Use @lwc/eslint-plugin-lwc@v1.x for older versions of eslint._
 
-Example of `.eslintrc`:
+Import `@lwc/eslint-plugin-lwc` and use it in the `plugins` section of your configuration as shown below. Then configure the desired rules in the `rules` sections. Some of the syntax used in Lightning Web Components is not yet stage 4 (eg. class fields or decorators), and the out-of-the-box parser from ESLint doesn't support this syntax yet. In order to parse the LWC files properly, set the `parser` field to [`@babel/eslint-parser`](https://github.com/babel/babel/tree/main/eslint/babel-eslint-parser) in the `languageOptions` section of the eslint config.
 
-```json
-{
-    "parser": "@babel/eslint-parser",
-    "parserOptions": {
-        "requireConfigFile": false,
-        "babelOptions": {
-            "parserOpts": {
-                "plugins": ["classProperties", ["decorators", { "decoratorsBeforeExport": false }]]
-            }
-        }
+Example of `eslint.config.js`:
+
+```js
+const eslintPluginLwc = require('@lwc/eslint-plugin-lwc');
+const babelParser = require('@babel/eslint-parser');
+
+module.exports = [
+    {
+        languageOptions: {
+            parser: babelParser,
+            parserOptions: {
+                requireConfigFile: false,
+                babelOptions: {
+                    parserOpts: {
+                        plugins: [
+                            'classProperties',
+                            ['decorators', { decoratorsBeforeExport: false }],
+                        ],
+                    },
+                },
+            },
+        },
+        plugins: {
+            '@lwc/lwc': eslintPluginLwc, // https://github.com/salesforce/eslint-plugin-lwc
+        },
+        rules: {
+            '@lwc/lwc/no-deprecated': 'error',
+            '@lwc/lwc/valid-api': 'error',
+            '@lwc/lwc/no-document-query': 'error',
+            '@lwc/lwc/ssr-no-unsupported-properties': 'error',
+        },
     },
-
-    "plugins": ["@lwc/eslint-plugin-lwc"],
-
-    "rules": {
-        "@lwc/lwc/no-deprecated": "error",
-        "@lwc/lwc/valid-api": "error",
-        "@lwc/lwc/no-document-query": "error",
-        "@lwc/lwc/ssr-no-unsupported-properties": "error"
-    }
-}
+];
 ```
 
 ### Usage with TypeScript
 
-To enable working with TypeScript projects, install `@babel/preset-typescript` as a dependency add `"typescript"` to `parserOptions.babelOptions.parserOpts.plugins` in your `.eslintrc`.
+To enable working with TypeScript projects, install `@babel/preset-typescript` as a dependency add `"typescript"` to `languageOptions.parserOptions.babelOptions.parserOpts.plugins` in your `eslint.config.js`.
 
 Example:
 
-```json
-{
-    "parserOptions": {
-        "babelOptions": {
-            "parserOpts": {
-                "plugins": [
-                    "classProperties",
-                    ["decorators", { "decoratorsBeforExport": false }],
-                    "typescript"
-                ]
-            }
-        }
-    }
-}
+```js
+const eslintPluginLwc = require('@lwc/eslint-plugin-lwc');
+const babelParser = require('@babel/eslint-parser');
+
+module.exports = [
+    {
+        languageOptions: {
+            parser: babelParser,
+            parserOptions: {
+                requireConfigFile: false,
+                babelOptions: {
+                    parserOpts: {
+                        plugins: [
+                            'classProperties',
+                            ['decorators', { decoratorsBeforeExport: false }],
+                            'typescript',
+                        ],
+                    },
+                },
+            },
+        },
+    },
+];
 ```
 
 For more details about configuration please refer to the dedicated section in the ESLint documentation: https://eslint.org/docs/user-guide/configuring

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@
  */
 'use strict';
 
+const { version } = require('../package.json');
+
 const rules = {
     'consistent-component-name': require('./rules/consistent-component-name'),
     'no-api-reassignments': require('./rules/no-api-reassignments'),
@@ -43,5 +45,10 @@ const rules = {
 };
 
 module.exports = {
+    // https://eslint.org/docs/latest/extend/plugins#meta-data-in-plugins
+    meta: {
+        name: '@lwc/eslint-plugin-lwc',
+        version,
+    },
     rules,
 };


### PR DESCRIPTION
redoing https://github.com/salesforce/eslint-plugin-lwc/pull/181 as I lost it to a force update.