### PR TITLE
fix: correct peer dependency notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "minimatch": "~9.0.4"
   },
   "peerDependencies": {
-    "@babel/eslint-parser": "^7",
-    "eslint": "^9"
+    "@babel/eslint-parser": "^7.x",
+    "eslint": "^9.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Requires .x in the version 
https://nodejs.org/en/blog/npm/peer-dependencies
The current version causes peer dependency errors