### PR TITLE
@W-19147397 processor updated to filter ssr rule disable warning from original files

### DIFF
--- a/lib/processors/ssr.js
+++ b/lib/processors/ssr.js
@@ -94,11 +94,22 @@ module.exports = {
                         message.message &&
                         message.message.includes('Unused eslint-disable directive')
                     ) {
+                        // Extract all rule names from the message
+                        const ruleMatches = message.message.match(/'([^']+)'/g) || [];
+                        const allRules = ruleMatches.map((rule) => rule.slice(1, -1)); // Remove quotes
+
+                        // Check if message contains any SSR rules
                         const ssrRulePattern = /@lwc\/lwc\/ssr-[\w-]+/;
-                        if (ssrRulePattern.test(message.message)) {
-                            // This is an unused disable directive warning for an SSR rule from original file - filter it out
+                        const ssrRules = allRules.filter((rule) => ssrRulePattern.test(rule));
+                        const nonSsrRules = allRules.filter((rule) => !ssrRulePattern.test(rule));
+
+                        // Only filter out if ALL rules in the message are SSR rules
+                        if (ssrRules.length > 0 && nonSsrRules.length === 0) {
+                            // This unused disable directive warning only contains SSR rules - filter it out
                             return false;
                         }
+                        // If mixed rules (SSR + non-SSR), keep the entire message unchanged
+                        // Once developer fixes the non-SSR rule, the SSR rule gets handled automatically
                     }
                     return true;
                 });


### PR DESCRIPTION
**Problem**

When using the SSR processor, developers get false "unused eslint-disable directive" warnings for SSR rules in original files. This happens because:
- Developers add SSR disable comments in original .js files (the only editable files)
- SSR rules only run on virtual .ssrjs files created by the processor
- ESLint flags SSR disable comments as "unused" in original files since SSR rules don't run there

**Solution**

Enhanced the SSR processor's postprocess method to filter out unused disable directive warnings specifically for SSR rules (@lwc/lwc/ssr-*) from original file messages.

Key features:
- Only filters SSR-related unused disable warnings from original files
- Preserves real SSR violations from virtual .ssrjs files
- Maintains non-SSR unused disable directive warnings
- No breaking changes